### PR TITLE
Add httpx and move httpc to httpx

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ There are two types of packages:
 - `ext`: extensions to the stdlib, they augment stdlib package functionalities. Usually named after a stdlib package name plus `x`.
 - `new`: they provide logic not present in the stdlib.
 
-| Package          | Type  | Description                                           |
-| ---              | ----  | -----------                                           |
-| [`httpc`](httpc) | `ext` | Adds decorators to `http.Client`                      |
-| [`logx`](logx)   | `ext` | Adds structured logging and logstash support to `log` |
+| Package          | Type  | Description                                                        |
+| ---              | ----  | -----------                                                        |
+| [`httpx`](httpx) | `ext` | Extends package `net/http` with routing utilities, decorators, etc |
+| [`logx`](logx)   | `ext` | Adds structured logging and logstash support to `log`              |
 
 ## Contributors
 

--- a/httpx/README.md
+++ b/httpx/README.md
@@ -1,0 +1,39 @@
+# package httpx
+
+`package httpx` provides a set of extensions to the `net/http` package.
+
+## Design Principles
+
+- Embrace the standard library
+    - use the standard library for as long as possible
+    - you may not need an external package at all
+    - use http.Handler and http.HandlerFunc
+- Use HTTP query strings instead of adding the complexity of a complex and slow multiplexer
+- Complex path structures ties to a fixed structure are difficult to remember and document
+- This is intended to be consumed by machines in most cases, not for final users
+- Method agnostic
+
+## Why not using an HTTP micro-framework?
+
+Because it's not needed at all:
+- We can use the standard library for as long as possible
+- We can use http.Handler and http.HandlerFunc as the core foundation of our HTTP services
+- Micro-frameworks often adds features we don't need:
+   - pretty (user friendly) URLs
+   - defaults intended for web sites and web development
+
+However, most of our services will be consumed by machines, where we can follow this principles:
+- HTTP query strings usage, instead of adding a complex and slow multiplexer to decode pretty paths
+- Method agnostic, this is not REST, we can express intentions in other ways (for example, RPC)
+
+
+## Decorators
+
+- They are shared functionality that you want to run for many (or even all) HTTP requests.
+- They wrap/decorate `http.Handler` with additional functionality.
+- They must be composable.
+
+For example, you might want to log every request, gzip every response, instrument or check security. These shared
+responsibilities are better implemented by decorating existing `http.Handler` implementations.
+
+To learn more see code and usage examples.

--- a/httpx/client.go
+++ b/httpx/client.go
@@ -1,6 +1,3 @@
-// Package httpc provides a set of features for easy extension of the default `net/http` client.
-// The idea is pretty simple, start with an http.DefaultClient and decorate it with the
-// extra functionality you need.
 package httpx
 
 import (

--- a/httpx/client_example_test.go
+++ b/httpx/client_example_test.go
@@ -1,17 +1,17 @@
-package httpc_test
+package httpx_test
 
 import (
 	"fmt"
 	"net/http"
 	"time"
 
-	"github.com/socialpoint-labs/bsk/httpc"
+	"github.com/socialpoint-labs/bsk/httpx"
 )
 
 func ExampleHeader() {
 	// Decorate the default client with a decorator that adds a header to all
 	// request issued
-	client := httpc.Decorate(http.DefaultClient, httpc.Header("test", "123"))
+	client := httpx.DecorateClient(http.DefaultClient, httpx.Header("test", "123"))
 
 	req, err := http.NewRequest("GET", "http://www.google.com/robots.txt", nil)
 
@@ -34,7 +34,7 @@ func ExampleFaultTolerance() {
 	attempts := 5
 	backoff := time.Millisecond * 500
 
-	client := httpc.Decorate(http.DefaultClient, httpc.FaultTolerance(attempts, backoff))
+	client := httpx.DecorateClient(http.DefaultClient, httpx.FaultTolerance(attempts, backoff))
 
 	req, err := http.NewRequest("GET", "http://www.google.com/robots.txt", nil)
 

--- a/httpx/client_test.go
+++ b/httpx/client_test.go
@@ -1,4 +1,4 @@
-package httpc_test
+package httpx_test
 
 import (
 	"bytes"
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/socialpoint-labs/bsk/httpc"
+	"github.com/socialpoint-labs/bsk/httpx"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,7 +46,7 @@ func (c *FailingClient) Do(*http.Request) (*http.Response, error) {
 func TestHeaderDecorator(t *testing.T) {
 	assert := assert.New(t)
 
-	client := httpc.Decorate(&NoopClient{}, httpc.Header("test", "123"))
+	client := httpx.DecorateClient(&NoopClient{}, httpx.Header("test", "123"))
 
 	req, err := http.NewRequest("GET", "http://example.com", nil)
 	assert.NoError(err)
@@ -61,7 +61,7 @@ func TestHeaderDecorator(t *testing.T) {
 func TestFaultTolerance(t *testing.T) {
 	assert := assert.New(t)
 
-	client := httpc.Decorate(&FailingClient{}, httpc.FaultTolerance(5, time.Millisecond))
+	client := httpx.DecorateClient(&FailingClient{}, httpx.FaultTolerance(5, time.Millisecond))
 
 	req, err := http.NewRequest("GET", "http://example.com", nil)
 	assert.NoError(err)
@@ -77,7 +77,7 @@ func TestLogger(t *testing.T) {
 
 	recorder := &bytes.Buffer{}
 
-	client := httpc.Decorate(&NoopClient{}, httpc.Logger(recorder))
+	client := httpx.DecorateClient(&NoopClient{}, httpx.Logger(recorder))
 
 	req, err := http.NewRequest("GET", "http://example.com", nil)
 	assert.NoError(err)
@@ -95,7 +95,7 @@ func TestLoggerf(t *testing.T) {
 	recorder := &bytes.Buffer{}
 
 	formatter := func(r *http.Request) string { return fmt.Sprintf("[%s][%s]", r.Method, r.URL.String()) }
-	client := httpc.Decorate(&NoopClient{}, httpc.Loggerf(recorder, formatter))
+	client := httpx.DecorateClient(&NoopClient{}, httpx.Loggerf(recorder, formatter))
 
 	req, err := http.NewRequest("GET", "http://example.com", nil)
 	assert.NoError(err)
@@ -110,13 +110,13 @@ func TestLoggerf(t *testing.T) {
 func TestFake(t *testing.T) {
 	assert := assert.New(t)
 
-	for _, fakes := range [][]httpc.FakeResponse{
-		{httpc.NewFake("foo", http.StatusOK)},
-		{httpc.NewFake("teapot", http.StatusTeapot)},
+	for _, fakes := range [][]httpx.FakeResponse{
+		{httpx.NewFake("foo", http.StatusOK)},
+		{httpx.NewFake("teapot", http.StatusTeapot)},
 		// multiple/successive
-		{httpc.NewFake("foo", http.StatusOK), httpc.NewFake("teapot", http.StatusTeapot)},
+		{httpx.NewFake("foo", http.StatusOK), httpx.NewFake("teapot", http.StatusTeapot)},
 	} {
-		client := httpc.Decorate(http.DefaultClient, httpc.Fake(fakes...))
+		client := httpx.DecorateClient(http.DefaultClient, httpx.Fake(fakes...))
 		assert.NotNil(client)
 
 		for _, fake := range fakes {
@@ -135,8 +135,8 @@ func TestFake(t *testing.T) {
 func TestConcurrentFake(t *testing.T) {
 	assert := assert.New(t)
 
-	r := httpc.NewFake("teapot", http.StatusTeapot)
-	client := httpc.Decorate(http.DefaultClient, httpc.Fake(r, r))
+	r := httpx.NewFake("teapot", http.StatusTeapot)
+	client := httpx.DecorateClient(http.DefaultClient, httpx.Fake(r, r))
 	assert.NotNil(client)
 
 	wg := &sync.WaitGroup{}
@@ -161,7 +161,7 @@ func TestConcurrentFake(t *testing.T) {
 func TestQueryDecorator(t *testing.T) {
 	assert := assert.New(t)
 
-	client := httpc.Decorate(&NoopClient{}, httpc.Query("test", "123"))
+	client := httpx.DecorateClient(&NoopClient{}, httpx.Query("test", "123"))
 
 	req, err := http.NewRequest("GET", "http://example.com", nil)
 	assert.NoError(err)

--- a/httpx/decorator.go
+++ b/httpx/decorator.go
@@ -1,0 +1,234 @@
+package httpx
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Decorator wraps/decorate a http.Handler with additional functionality.
+type Decorator func(http.Handler) http.Handler
+
+// CloseNotifierDecorator returns a decorator that cancels the context when the client
+// connection closes unexpectedly.
+//
+// The http.CloseNotifier interface is implemented by http.ResponseWriters which
+// allows detecting when the underlying connection has gone away.
+//
+// This mechanism can be used to cancel long operations on the server
+// if the client has disconnected before the response is ready.
+func CloseNotifierDecorator() Decorator {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Cancel the context if the client closes the connection
+			if wcn, ok := w.(http.CloseNotifier); ok {
+				ctx, cancel := context.WithCancel(r.Context())
+				r = r.WithContext(ctx)
+
+				// Canceling this context releases resources associated with it, so code should
+				// call cancel as soon as the operations running in this Context complete.
+				// As we have created a new context here, we are responsible for releasing it's resources
+				// by calling the cancellation function.
+				defer cancel()
+
+				// CloseNotify returns a channel that receives at most a single value when
+				// the client connection has gone away.
+
+				// Runs a go-routine to receive this notification and cancel the request context
+				go func() {
+					select {
+					case <-wcn.CloseNotify():
+						cancel()
+					case <-ctx.Done():
+					}
+				}()
+			}
+
+			h.ServeHTTP(w, r)
+		})
+	}
+}
+
+// AddHeaderDecorator returns a decorator that adds the given header to the HTTP response.
+func AddHeaderDecorator(key, value string) Decorator {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add(key, value)
+			h.ServeHTTP(w, r)
+		})
+	}
+}
+
+// SetHeaderDecorator returns a decorator that sets the given header to the HTTP response.
+func SetHeaderDecorator(key, value string) Decorator {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set(key, value)
+			h.ServeHTTP(w, r)
+		})
+	}
+}
+
+// CheckHeaderDecorator returns a decorator that checks if the given request header
+// matches the given value, if the header does not exist or doesn't match then
+// respond with the provided status code header and its value as content.
+func CheckHeaderDecorator(headerName, headerValue string, statusCode int) Decorator {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			value := r.Header.Get(headerName)
+			if value != headerValue {
+				w.WriteHeader(statusCode)
+				// we don't care about the error if we can't write
+				_, _ = w.Write([]byte(http.StatusText(statusCode)))
+				return
+			}
+
+			h.ServeHTTP(w, r)
+		})
+	}
+}
+
+// CheckSPAuthHeaderDecorator checks for the sign header with the provided secret,
+// if doesn't match will return HTTP 401.
+func CheckSPAuthHeaderDecorator(secret string) Decorator {
+	return CheckHeaderDecorator("X-SP-Sign", secret, http.StatusUnauthorized)
+}
+
+// RootDecorator decorates a handler to distinguish root path from 404s
+// ServeMux matches "/" for both, root path and all unmatched URLs
+// How to bypass: https://golang.org/pkg/net/http/#example_ServeMux_Handle
+func RootDecorator() Decorator {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/" {
+				http.NotFound(w, r)
+				return
+			}
+
+			h.ServeHTTP(w, r)
+		})
+	}
+}
+
+// StripPrefixDecorator removes prefix from URL.
+func StripPrefixDecorator(prefix string) Decorator {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if p := strings.TrimPrefix(r.URL.Path, prefix); len(p) < len(r.URL.Path) {
+				r.URL.Path = p
+				h.ServeHTTP(w, r)
+			} else {
+				http.NotFound(w, r)
+			}
+		})
+	}
+}
+
+// EnableCORSDecorator adds required response headers to enable CORS and serves OPTIONS requests.
+func EnableCORSDecorator() Decorator {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Origin,Accept,Content-Type,Authorization")
+
+			// Stop here if its Preflighted OPTIONS request
+			if r.Method == "OPTIONS" {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+
+			h.ServeHTTP(w, r)
+		})
+	}
+}
+
+// Condition represents a condition based on the http.Request and the current state of the http.ResponseWriter
+type Condition func(w http.ResponseWriter, r *http.Request) bool
+
+// IfDecorator is a special adapter that will skip to the 'then' handler if a condition
+// applies at runtime, or pass the control to the adapted handler otherwise.
+func IfDecorator(cond Condition, then http.Handler) Decorator {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if cond(w, r) {
+				then.ServeHTTP(w, r)
+			} else {
+				h.ServeHTTP(w, r)
+			}
+		})
+	}
+}
+
+// TimeoutDecorator returns a adapter which adds a timeout to the context.
+// Child handlers have the responsibility to obey the context deadline
+func TimeoutDecorator(timeout time.Duration) Decorator {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx, cancel := context.WithTimeout(r.Context(), timeout)
+			defer cancel()
+
+			r = r.WithContext(ctx)
+
+			h.ServeHTTP(w, r)
+		})
+	}
+}
+
+// LoggingDecorator returns an adapter that log requests to a given logger
+func LoggingDecorator(logWriter io.Writer) Decorator {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			resLogger := &responseLogger{w, 0, 0}
+			h.ServeHTTP(resLogger, req)
+			fmt.Fprintln(logWriter, formatLogLine(req, time.Now(), resLogger.Status(), resLogger.Size()))
+		})
+	}
+}
+
+func formatLogLine(req *http.Request, ts time.Time, status int, size int) string {
+	host, _, err := net.SplitHostPort(req.RemoteAddr)
+	if err != nil {
+		host = req.RemoteAddr
+	}
+
+	uri := req.URL.RequestURI()
+	formattedTime := ts.Format("02/Jan/2006:15:04:05 -0700")
+
+	return fmt.Sprintf("%s [%s] %s %s %s %d %d", host, formattedTime, req.Method, uri, req.Proto, status, size)
+}
+
+// responseLogger is wrapper of http.ResponseWriter that keeps track of its HTTP
+// status code and body size
+type responseLogger struct {
+	http.ResponseWriter
+	status int
+	size   int
+}
+
+func (l *responseLogger) Write(b []byte) (int, error) {
+	if l.status == 0 {
+		// The status will be StatusOK if WriteHeader has not been called yet
+		l.status = http.StatusOK
+	}
+	size, err := l.ResponseWriter.Write(b)
+	l.size += size
+	return size, err
+}
+
+func (l *responseLogger) WriteHeader(s int) {
+	l.ResponseWriter.WriteHeader(s)
+	l.status = s
+}
+
+func (l responseLogger) Status() int {
+	return l.status
+}
+
+func (l responseLogger) Size() int {
+	return l.size
+}

--- a/httpx/decorator_test.go
+++ b/httpx/decorator_test.go
@@ -1,0 +1,279 @@
+package httpx_test
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/socialpoint-labs/bsk/httpx"
+	"github.com/stretchr/testify/assert"
+)
+
+type closeNotifyWriter struct {
+	*httptest.ResponseRecorder
+	closed bool
+}
+
+func (w *closeNotifyWriter) CloseNotify() <-chan bool {
+	notify := make(chan bool, 1)
+	if w.closed {
+		// return an already "closed" notifier
+		notify <- true
+	}
+	return notify
+}
+
+func TestCloseNotifierDecorator_Client_Close_Connections(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		<-ctx.Done()
+		if ctx.Err() == context.Canceled {
+			w.Header().Set("status", "canceled")
+		}
+	})
+
+	h := httpx.CloseNotifierDecorator()(handler)
+
+	w := &closeNotifyWriter{ResponseRecorder: httptest.NewRecorder(), closed: true}
+
+	r, err := http.NewRequest("GET", "http://example.com/foo", nil)
+	assert.NoError(t, err)
+
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, w.Header().Get("status"), "canceled")
+}
+
+func TestCloseNotifierDecorator_Request_Ends_Without_Cancelation(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		if ctx.Err() == context.Canceled {
+			w.Header().Set("status", "canceled")
+		}
+	})
+
+	h := httpx.CloseNotifierDecorator()(handler)
+
+	w := &closeNotifyWriter{ResponseRecorder: httptest.NewRecorder(), closed: false}
+
+	r, err := http.NewRequest("GET", "http://example.com/foo", nil)
+	assert.NoError(t, err)
+
+	h.ServeHTTP(w, r)
+
+	assert.NotEqual(t, w.Header().Get("status"), "canceled")
+}
+
+func TestAddHeaderDecorator(t *testing.T) {
+	assert := assert.New(t)
+
+	h := httpx.AddHeaderDecorator("key", "value1")(
+		httpx.AddHeaderDecorator("key", "value2")(
+			httpx.NoopHandler()))
+
+	w := httptest.NewRecorder()
+	r := &http.Request{}
+
+	h.ServeHTTP(w, r)
+
+	headers := w.HeaderMap[http.CanonicalHeaderKey("key")]
+	assert.Equal("value1", headers[0])
+	assert.Equal("value2", headers[1])
+}
+
+func TestSetHeaderDecorator(t *testing.T) {
+	assert := assert.New(t)
+
+	h := httpx.SetHeaderDecorator("key", "value1")(
+		httpx.SetHeaderDecorator("key", "value2")(
+			httpx.NoopHandler()))
+
+	w := httptest.NewRecorder()
+	r := &http.Request{}
+
+	h.ServeHTTP(w, r)
+
+	assert.Equal("value2", w.Header().Get("key"))
+}
+
+func TestCheckHeaderDecorator(t *testing.T) {
+	assert := assert.New(t)
+
+	header := "foo"
+	value := "bar"
+	code := http.StatusInternalServerError
+
+	w := httptest.NewRecorder()
+	r := &http.Request{}
+
+	handler := httpx.CheckHeaderDecorator(header, value, code)(httpx.NoopHandler())
+
+	handler.ServeHTTP(w, r)
+	assert.Equal(w.Code, code)
+	content, err := ioutil.ReadAll(w.Body)
+	assert.NoError(err)
+	assert.Equal(string(content), "Internal Server Error")
+
+	// now try the same thing but with the header in the request
+	r, err = http.NewRequest("GET", "http://foo.bar", nil)
+	assert.NoError(err)
+	r.Header.Set(header, value)
+
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	assert.Equal(w.Code, http.StatusOK)
+	content, err = ioutil.ReadAll(w.Body)
+	assert.NoError(err)
+	assert.Equal(string(content), "")
+}
+
+func TestCheckSPAuthHeaderDecorator(t *testing.T) {
+	assert := assert.New(t)
+
+	secret := "secret"
+
+	handler := httpx.CheckSPAuthHeaderDecorator(secret)(httpx.NoopHandler())
+
+	w := httptest.NewRecorder()
+	r := &http.Request{}
+
+	handler.ServeHTTP(w, r)
+	assert.Equal(w.Code, http.StatusUnauthorized)
+	_, err := ioutil.ReadAll(w.Body)
+	assert.NoError(err)
+
+	// put the secret header and should go ok
+	r, err = http.NewRequest("GET", "http://foo.bar", nil)
+	assert.NoError(err)
+	r.Header.Set("X-SP-Sign", secret)
+
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	assert.Equal(w.Code, http.StatusOK)
+	content, err := ioutil.ReadAll(w.Body)
+	assert.NoError(err)
+	assert.Equal(string(content), "")
+}
+
+func TestRootDecorator(t *testing.T) {
+	assert := assert.New(t)
+
+	h := httpx.RootDecorator()(httpx.NoopHandler())
+
+	// Test a request to the root path
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/", nil)
+	assert.NoError(err)
+
+	h.ServeHTTP(w, req)
+	assert.Equal(http.StatusOK, w.Code)
+
+	// Test  a request to a random non-root path
+	w = httptest.NewRecorder()
+	req, err = http.NewRequest("GET", "/whatever", nil)
+	assert.NoError(err)
+
+	h.ServeHTTP(w, req)
+	assert.Equal(http.StatusNotFound, w.Code)
+
+}
+
+func TestEnableCORSDecorator(t *testing.T) {
+	assert := assert.New(t)
+
+	h := httpx.EnableCORSDecorator()(httpx.NoopHandler())
+
+	w := httptest.NewRecorder()
+	r := &http.Request{}
+	r.Method = "OPTIONS"
+
+	h.ServeHTTP(w, r)
+
+	assert.Equal("*", w.HeaderMap.Get("Access-Control-Allow-Origin"))
+	assert.Equal("GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS", w.HeaderMap.Get("Access-Control-Allow-Methods"))
+	assert.Equal("Origin,Accept,Content-Type,Authorization", w.HeaderMap.Get("Access-Control-Allow-Headers"))
+
+	assert.Equal(http.StatusOK, w.Code)
+}
+
+func TestIfDecorator(t *testing.T) {
+	trueHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("cond", "true")
+	})
+
+	cond := func(w http.ResponseWriter, r *http.Request) bool {
+		return r.URL.Path == "/true"
+	}
+
+	h := httpx.IfDecorator(cond, trueHandler)(httpx.NoopHandler())
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "http://example.com/true", nil)
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, "true", w.Header().Get("cond"))
+
+	w = httptest.NewRecorder()
+	r, _ = http.NewRequest("GET", "http://example.com/false", nil)
+	h.ServeHTTP(nil, r)
+
+	assert.Equal(t, "", w.Header().Get("cond"))
+}
+
+func TestTimeoutDecorator(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := r.Context().Deadline(); ok {
+			w.Header().Set("status", "deadline")
+		}
+	})
+
+	h := httpx.TimeoutDecorator(time.Second)(handler)
+
+	w := httptest.NewRecorder()
+	r, err := http.NewRequest("GET", "http://example.com/foo", nil)
+	assert.NoError(t, err)
+
+	h.ServeHTTP(w, r)
+	assert.Equal(t, "deadline", w.Header().Get("status"))
+}
+
+type writerMock struct {
+	io.Writer
+	loggedBytes []byte
+}
+
+func TestLogging(t *testing.T) {
+	writerMock := &writerMock{}
+	text := "Test OK"
+
+	router := httpx.NewRouter()
+	router.Route(
+		"/test",
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, text)
+		}),
+		httpx.LoggingDecorator(writerMock),
+	)
+
+	recorder := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://localhost:8080/test", nil)
+	router.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, text, recorder.Body.String())
+
+	assert.Contains(t, string(writerMock.loggedBytes), "GET /test HTTP/1.1 200")
+}
+
+func (w *writerMock) Write(p []byte) (n int, err error) {
+	w.loggedBytes = append(w.loggedBytes, p...)
+
+	return len(p), nil
+}

--- a/httpx/encoder.go
+++ b/httpx/encoder.go
@@ -1,0 +1,33 @@
+package httpx
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Encoder describes an object capable of encoding a response.
+type Encoder interface {
+	// Encode writes a serialization of v to w, optionally using additional
+	// information from the http.Request to do so.
+	Encode(w http.ResponseWriter, r *http.Request, v interface{}) error
+
+	// ContentType gets a string that will become the Content-Type header
+	// when responding through w to the specified http.Request.
+	// Most of the time the argument will be ignored, but occasionally
+	// details in the request, or even in the headers in the ResponseWriter may
+	// change the content type.
+	ContentType(w http.ResponseWriter, r *http.Request) string
+}
+
+// JSONEncoder is an Encoder for JSON.
+var JSONEncoder Encoder = (*jsonEncoder)(nil)
+
+type jsonEncoder struct{}
+
+func (*jsonEncoder) Encode(w http.ResponseWriter, r *http.Request, v interface{}) error {
+	return json.NewEncoder(w).Encode(v)
+}
+
+func (*jsonEncoder) ContentType(w http.ResponseWriter, r *http.Request) string {
+	return "application/json; charset=utf-8"
+}

--- a/httpx/encoder_test.go
+++ b/httpx/encoder_test.go
@@ -1,0 +1,52 @@
+package httpx
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var testdata = map[string]interface{}{"test": true}
+
+func newTestRequest() *http.Request {
+	r, err := http.NewRequest("GET", "Something", nil)
+	if err != nil {
+		panic("bad request: " + err.Error())
+	}
+	return r
+}
+
+func TestJSON(t *testing.T) {
+	assert := assert.New(t)
+
+	w := httptest.NewRecorder()
+	r := newTestRequest()
+
+	assert.Equal(JSONEncoder.ContentType(w, r), "application/json; charset=utf-8")
+	assert.NoError(JSONEncoder.Encode(w, r, testdata))
+
+	var data map[string]interface{}
+	assert.NoError(json.Unmarshal(w.Body.Bytes(), &data))
+	assert.Equal(data, testdata)
+}
+
+type testEncoder struct{}
+
+func (testEncoder) Encode(w http.ResponseWriter, r *http.Request, v interface{}) error {
+	return nil
+}
+func (testEncoder) ContentType(w http.ResponseWriter, r *http.Request) string {
+	return "test/encoder"
+}
+
+func testRequestWithAccept(accept string) *http.Request {
+	r, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		panic("bad request: " + err.Error())
+	}
+	r.Header.Set("Accept", accept)
+	return r
+}

--- a/httpx/example_test.go
+++ b/httpx/example_test.go
@@ -1,0 +1,44 @@
+package httpx_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/socialpoint-labs/bsk/httpx"
+)
+
+func Example_Router_Multi_Route_Endpoint_With_Prefix() {
+	writer := func() http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			fmt.Println(r.URL.String())
+		}
+	}
+
+	nestedRouter := httpx.NewRouter()
+	nestedRouter.Route("/p1", writer())
+	nestedRouter.Route("/p2", writer())
+
+	router := httpx.NewRouter()
+	router.Route("/prefix", nestedRouter)
+
+	w := httptest.NewRecorder()
+	r, err := http.NewRequest("GET", "/prefix/p1", nil)
+	if err != nil {
+		panic(err)
+	}
+
+	router.ServeHTTP(w, r)
+
+	w = httptest.NewRecorder()
+	r, err = http.NewRequest("GET", "/prefix/p2", nil)
+	if err != nil {
+		panic(err)
+	}
+
+	router.ServeHTTP(w, r)
+
+	// Output:
+	// /p1
+	// /p2
+}

--- a/httpx/handler.go
+++ b/httpx/handler.go
@@ -1,0 +1,21 @@
+package httpx
+
+import (
+	"net/http"
+)
+
+// NoopHandler returns a ContextAwareHandler that does nothing when it receives a request
+func NoopHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {}
+}
+
+// StatusHandler returns a ContextAwareHandler handler that replies with the give status code.
+func StatusHandler(status int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+	}
+}
+
+// StatusOKHandler is a simple ContextAwareHandler that always reply with status 200,
+// useful to be used for health checker handlers or tests.
+var StatusOKHandler = StatusHandler(http.StatusOK)

--- a/httpx/handler_test.go
+++ b/httpx/handler_test.go
@@ -1,0 +1,23 @@
+package httpx_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/socialpoint-labs/bsk/httpx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusHandler(t *testing.T) {
+	assert := assert.New(t)
+
+	for _, code := range []int{200, 250, 300, 330, 404, 500, 505} {
+
+		h := httpx.StatusHandler(code)
+		w := httptest.NewRecorder()
+
+		h.ServeHTTP(w, &http.Request{})
+		assert.Equal(code, w.Code)
+	}
+}

--- a/httpx/responder.go
+++ b/httpx/responder.go
@@ -1,0 +1,103 @@
+package httpx
+
+import (
+	"net/http"
+)
+
+// NewResponder returns a new Responder
+func NewResponder() *Responder {
+	return &Responder{}
+}
+
+// Responder actually write responses, typically at the end of an HTTP request
+type Responder struct {
+	// OnErr is a function that gets called when an error occurs while responding.
+	// By default, the error panic but you may
+	// use Options.OnErrLog to just log the error out instead,
+	// or provide your own.
+	OnErr func(err error)
+
+	// Encoder is a function field that gets the encoder to
+	// use to respond to the specified http.Request.
+	// If nil, JSON will be used.
+	Encoder func(w http.ResponseWriter, r *http.Request) Encoder
+
+	// Before is called for before each response is written
+	// and gives user code the chance to mutate the status or data.
+	// Useful for handling different types of data differently (like errors),
+	// enveloping the response, setting common HTTP headers etc.
+	Before func(w http.ResponseWriter, r *http.Request, status int, data interface{}) (int, interface{})
+
+	// After is called after each response.
+	// Useful for logging activity after a response has been written.
+	After func(w http.ResponseWriter, r *http.Request, status int, data interface{})
+
+	// StatusData is a function field that gets the data to respond with when
+	// WithStatus is called.
+	// By default, the function will return an object that looks like this:
+	//     {"status":"Not Found","code":404}
+	StatusData func(w http.ResponseWriter, r *http.Request, status int) interface{}
+}
+
+// Respond uses the http.ResponseWriter for writing the response data and status
+func (o *Responder) Respond(w http.ResponseWriter, r *http.Request, status int, data interface{}) {
+	encoder := JSONEncoder // JSON by default
+
+	if o.Before != nil {
+		status, data = o.Before(w, r, status, data)
+	}
+
+	if o.Encoder != nil {
+		encoder = o.Encoder(w, r)
+	}
+
+	// Actually write the response
+	w.Header().Set("Content-Type", encoder.ContentType(w, r))
+
+	w.WriteHeader(status)
+
+	if err := encoder.Encode(w, r, data); err != nil {
+		if o.OnErr != nil {
+			o.OnErr(err)
+		} else {
+			panic("respond: " + err.Error())
+		}
+	}
+
+	if o.After != nil {
+		o.After(w, r, status, data)
+	}
+}
+
+// WithStatus responds to the client with the specified status.
+// Responder.StatusData will be called to obtain the data payload, or a default
+// payload will be returned:
+//     {"status":"I'm a teapot","code":418}
+func (o *Responder) WithStatus(w http.ResponseWriter, r *http.Request, status int) {
+	var data interface{}
+	if o.StatusData != nil {
+		data = o.StatusData(w, r, status)
+	} else {
+		data = map[string]interface{}{"status": http.StatusText(status), "code": status}
+	}
+
+	o.Respond(w, r, status, data)
+}
+
+// RespondWith returns an option that sets a responder
+func RespondWith(r *Responder) Option {
+	return func(o *options) {
+		o.responder = r
+	}
+}
+
+// Respond extracts a responder from the context and writes the data and status to the http.ResponseWriter
+func Respond(w http.ResponseWriter, r *http.Request, status int, data interface{}) {
+	var responder *Responder
+	var ok bool
+	if responder, ok = r.Context().Value(responderKey).(*Responder); !ok {
+		responder = NewResponder()
+	}
+
+	responder.Respond(w, r, status, data)
+}

--- a/httpx/router.go
+++ b/httpx/router.go
@@ -1,0 +1,101 @@
+package httpx
+
+import (
+	"net/http"
+
+	"strings"
+
+	"context"
+)
+
+// NewRouter returns a new Router struct
+func NewRouter(opts ...Option) *Router {
+	options := &options{}
+	for _, o := range opts {
+		o(options)
+	}
+
+	if options.responder == nil {
+		options.responder = NewResponder()
+	}
+
+	return &Router{
+		options: options,
+		mux:     http.NewServeMux(),
+	}
+}
+
+// Router allows to route requests to according handlers
+type Router struct {
+	options     *options
+	routes      []*route
+	mux         *http.ServeMux
+	initialized bool
+}
+
+// Route registers a route pattern against its handler
+func (router *Router) Route(pattern string, handler http.Handler, decorators ...Decorator) {
+	router.routes = append(router.routes, &route{pattern, handler, decorators})
+}
+
+// ServeHTTP implements http.Handler
+func (router *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !router.initialized {
+		registerRoutes(router.mux, router, "", []Decorator{})
+		router.initialized = true
+	}
+
+	h, _ := router.mux.Handler(r)
+
+	ctx := context.WithValue(r.Context(), responderKey, router.options.responder)
+
+	r = r.WithContext(ctx)
+
+	h.ServeHTTP(w, r)
+}
+
+type route struct {
+	pattern    string
+	handler    http.Handler
+	decorators []Decorator
+}
+
+func registerRoutes(mux *http.ServeMux, router *Router, prefix string, decorators []Decorator) {
+	for _, r := range router.routes {
+		uri := prefix + r.pattern
+		if uri != "/" {
+			uri = strings.TrimRight(uri, "/")
+		}
+
+		if child, ok := r.handler.(*Router); ok {
+			registerRoutes(mux, child, uri, append(r.decorators, decorators...))
+		} else {
+			if uri == "/" {
+				r.decorators = append(r.decorators, RootDecorator())
+			}
+
+			if prefix != "" {
+				r.decorators = append(r.decorators, StripPrefixDecorator(prefix))
+			}
+
+			for _, decorator := range append(r.decorators, decorators...) {
+				r.handler = decorator(r.handler)
+			}
+
+			mux.Handle(uri, r.handler)
+		}
+	}
+}
+
+// Option is the common type of functions that set options
+type Option func(*options)
+
+type options struct {
+	responder *Responder
+}
+
+type contextKey int
+
+const (
+	responderKey contextKey = iota
+)

--- a/httpx/router_test.go
+++ b/httpx/router_test.go
@@ -1,0 +1,192 @@
+package httpx
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRouterRootPathMatch(t *testing.T) {
+	assert := assert.New(t)
+
+	req, err := http.NewRequest("GET", "/", nil)
+	recorder := httptest.NewRecorder()
+
+	r := NewRouter()
+	r.Route("/", StatusOKHandler)
+	r.ServeHTTP(recorder, req)
+
+	assert.NoError(err)
+	assert.Equal(http.StatusOK, recorder.Code)
+}
+
+func TestRouterNotFound(t *testing.T) {
+	assert := assert.New(t)
+
+	req, err := http.NewRequest("GET", "/hello", nil)
+	recorder := httptest.NewRecorder()
+
+	r := NewRouter()
+	r.ServeHTTP(recorder, req)
+
+	assert.NoError(err)
+	assert.Equal(http.StatusNotFound, recorder.Code)
+}
+
+func TestRouterInvalidPathDoesNotMatch(t *testing.T) {
+	assert := assert.New(t)
+
+	req, err := http.NewRequest("GET", "/hello", nil)
+	recorder := httptest.NewRecorder()
+
+	r := NewRouter()
+	r.Route("/", StatusOKHandler)
+	r.ServeHTTP(recorder, req)
+
+	assert.NoError(err)
+	assert.Equal(http.StatusNotFound, recorder.Code)
+}
+
+func TestRouterOK(t *testing.T) {
+	assert := assert.New(t)
+
+	req, err := http.NewRequest("GET", "/hello", nil)
+	recorder := httptest.NewRecorder()
+
+	r := NewRouter()
+	r.Route("/hello", StatusOKHandler)
+	r.ServeHTTP(recorder, req)
+
+	assert.NoError(err)
+	assert.Equal(http.StatusOK, recorder.Code)
+}
+
+func TestRouterAdapterAdaptsOneOfMultipleHandlers(t *testing.T) {
+	assert := assert.New(t)
+
+	key := "key"
+	value := "value"
+
+	r := NewRouter()
+	r.Route("/hello", NoopHandler())
+	r.Route("/custom", AddValueToContextDecorator(key, value)(NoopHandler()))
+
+	req, err := http.NewRequest("GET", "/hello", nil)
+	recorder := httptest.NewRecorder()
+
+	r.ServeHTTP(recorder, req)
+
+	assert.NoError(err)
+	assert.Equal(http.StatusOK, recorder.Code)
+	assert.Equal("", recorder.Header().Get("custom"))
+
+	req, err = http.NewRequest("GET", "/custom", nil)
+	recorder = httptest.NewRecorder()
+
+	r.ServeHTTP(recorder, req)
+
+	assert.NoError(err)
+	assert.Equal(http.StatusOK, recorder.Code)
+	assert.Equal(value, recorder.Header().Get(key))
+
+}
+
+func TestRouterWithDecorators(t *testing.T) {
+	assert := assert.New(t)
+
+	decorators := []Decorator{
+		CheckSPAuthHeaderDecorator("valid"),
+		EnableCORSDecorator(),
+	}
+
+	routerHello := NewRouter()
+	routerHello.Route("/foo", StatusOKHandler)
+
+	routerAdmin := NewRouter()
+	routerAdmin.Route("/hello", routerHello)
+	routerAdmin.Route("/world", StatusOKHandler)
+
+	routerDashboard := NewRouter()
+	routerDashboard.Route("/", StatusOKHandler)
+
+	router := NewRouter()
+	router.Route("/", StatusOKHandler)
+	router.Route("/_catalog", StatusOKHandler, decorators...)
+	router.Route("/admin", routerAdmin, decorators...)
+	router.Route("/dashboard", routerDashboard)
+
+	for _, testcase := range []struct {
+		uri            string
+		expectedStatus int
+		secret         string
+	}{
+		{"/", http.StatusOK, ""},
+		{"/admin", http.StatusNotFound, ""},
+		{"/_catalog", http.StatusUnauthorized, ""},
+		{"/admin/hello/foo", http.StatusUnauthorized, ""},
+		{"/admin/world", http.StatusUnauthorized, ""},
+		{"/_catalog", http.StatusUnauthorized, "invalid"},
+		{"/admin/hello/foo", http.StatusUnauthorized, "invalid"},
+		{"/admin/world", http.StatusUnauthorized, "invalid"},
+		{"/_catalog", http.StatusOK, "valid"},
+		{"/admin/hello/foo", http.StatusOK, "valid"},
+		{"/admin/world", http.StatusOK, "valid"},
+		{"/dashboard", http.StatusOK, ""},
+	} {
+		req, err := http.NewRequest("GET", testcase.uri, nil)
+		recorder := httptest.NewRecorder()
+
+		if testcase.secret != "" {
+			req.Header.Add("X-SP-Sign", testcase.secret)
+		}
+
+		router.ServeHTTP(recorder, req)
+
+		assert.NoError(err)
+		assert.Equal(testcase.expectedStatus, recorder.Code, fmt.Sprintf("testcase: (%v, %v, %v)", testcase.uri, testcase.expectedStatus, testcase.secret))
+	}
+}
+
+func TestDecoratorsAreOnlyExecutedOnce(t *testing.T) {
+	assert := assert.New(t)
+	var count int
+
+	worldRouter := NewRouter()
+	worldRouter.Route("/", StatusOKHandler)
+
+	helloRouter := NewRouter()
+	helloRouter.Route("/world", worldRouter)
+
+	baseRouter := NewRouter()
+	baseRouter.Route("/hello", helloRouter, countDecorator(&count))
+
+	req, err := http.NewRequest("GET", "/hello/world", nil)
+	recorder := httptest.NewRecorder()
+
+	baseRouter.ServeHTTP(recorder, req)
+
+	assert.NoError(err)
+	assert.Equal(http.StatusOK, recorder.Code)
+	assert.Equal(1, count, "Decorators are being executed more than once per request")
+}
+
+func AddValueToContextDecorator(key, value string) Decorator {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add(key, value)
+			h.ServeHTTP(w, r)
+		})
+	}
+}
+
+func countDecorator(count *int) Decorator {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			*count++
+			h.ServeHTTP(w, r)
+		})
+	}
+}

--- a/httpx/status.go
+++ b/httpx/status.go
@@ -1,0 +1,46 @@
+package httpx
+
+import "net/http"
+
+// ResponseIsSuccessful returns whether the response is successful
+func ResponseIsSuccessful(resp *http.Response) bool {
+	return IsSuccessful(resp.StatusCode)
+}
+
+// ResponseIsRedirection returns whether the response is a redirect
+func ResponseIsRedirection(resp *http.Response) bool {
+	return IsRedirection(resp.StatusCode)
+}
+
+// ResponseIsClientError returns whether the response is a client error
+func ResponseIsClientError(resp *http.Response) bool {
+	return IsClientError(resp.StatusCode)
+}
+
+// ResponseIsServerError returns whether the response is a server error
+func ResponseIsServerError(resp *http.Response) bool {
+	return IsServerError(resp.StatusCode)
+}
+
+// StatusFunc is a function that recives a status code and returns a boolean.
+type StatusFunc func(code int) bool
+
+// IsSuccessful returns whether the response is successful
+func IsSuccessful(code int) bool {
+	return code >= 200 && code < 300
+}
+
+// IsRedirection returns whether the codeonse is a redirect
+func IsRedirection(code int) bool {
+	return code >= 300 && code < 400
+}
+
+// IsClientError returns whether the codeonse is a client error
+func IsClientError(code int) bool {
+	return code >= 400 && code < 500
+}
+
+// IsServerError returns whether the codeonse is a server error
+func IsServerError(code int) bool {
+	return code >= 500 && code < 600
+}

--- a/httpx/status_test.go
+++ b/httpx/status_test.go
@@ -1,0 +1,28 @@
+package httpx_test
+
+import (
+	"testing"
+
+	"github.com/socialpoint-labs/bsk/httpx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsClientError(t *testing.T) {
+	assert.True(t, httpx.IsClientError(403))
+	assert.False(t, httpx.IsClientError(200))
+}
+
+func TestIsSuccessful(t *testing.T) {
+	assert.True(t, httpx.IsSuccessful(204))
+	assert.False(t, httpx.IsSuccessful(500))
+}
+
+func TestIsRedirection(t *testing.T) {
+	assert.True(t, httpx.IsRedirection(301))
+	assert.False(t, httpx.IsRedirection(200))
+}
+
+func TestIsServerError(t *testing.T) {
+	assert.True(t, httpx.IsServerError(502))
+	assert.False(t, httpx.IsServerError(200))
+}


### PR DESCRIPTION
Fixes https://github.com/socialpoint-labs/bsk/issues/8.
- renamed `httpc.Decorator` to `httpx.ClientDecorator`
- left `Decorator` as the `http.Handler` decorator type name.
- removed the `instrument.go` file and its test because depends on the metrics pkg that has not been imported yet.

If it's merged I'll create an issue to import the metrics package.