### PR TITLE
Make private all fields in metrics recorders

### DIFF
--- a/metrics/recorder.go
+++ b/metrics/recorder.go
@@ -43,8 +43,8 @@ type RecorderCounter struct {
 	mu    sync.Mutex // protects the whole struct
 }
 
-// Val returns the counter value in a thread-safe manner
-func (c *RecorderCounter) Val() uint64 {
+// Value returns the counter value in a thread-safe manner
+func (c *RecorderCounter) Value() uint64 {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.value
@@ -85,8 +85,8 @@ type RecorderGauge struct {
 	mu    sync.Mutex // protects the whole struct
 }
 
-// Val returns the counter value in a thread-safe manner
-func (g *RecorderGauge) Val() interface{} {
+// Value returns the counter value in a thread-safe manner
+func (g *RecorderGauge) Value() interface{} {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	return g.value
@@ -227,8 +227,8 @@ type RecorderHistogram struct {
 	mu     sync.Mutex // protects the whole struct
 }
 
-// Vals returns the histogram values in a thread-safe manner
-func (h *RecorderHistogram) Vals() []uint64 {
+// Values returns the histogram values in a thread-safe manner
+func (h *RecorderHistogram) Values() []uint64 {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	return h.values

--- a/metrics/recorder.go
+++ b/metrics/recorder.go
@@ -39,7 +39,7 @@ func (rm RecorderMetric) Tags() Tags {
 // A RecorderCounter is a RecorderMetric that implements Counter.
 type RecorderCounter struct {
 	RecorderMetric
-	Value uint64
+	value uint64
 	mu    sync.Mutex // protects the whole struct
 }
 
@@ -47,8 +47,7 @@ type RecorderCounter struct {
 func (c *RecorderCounter) Val() uint64 {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-
-	return c.Value
+	return c.value
 }
 
 // Inc implements the Counter behaviour and stores the value in the Recorder.
@@ -60,7 +59,7 @@ func (c *RecorderCounter) Inc() {
 func (c *RecorderCounter) Add(delta uint64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.Value += delta
+	c.value += delta
 }
 
 // WithTags adds the passed tags to the Tags recorder map.
@@ -82,15 +81,22 @@ func (c *RecorderCounter) WithTag(key string, value interface{}) Counter {
 // A RecorderGauge is a RecorderMetric that implements Gauge.
 type RecorderGauge struct {
 	RecorderMetric
-	Value interface{}
+	value interface{}
 	mu    sync.Mutex // protects the whole struct
+}
+
+// Val returns the counter value in a thread-safe manner
+func (g *RecorderGauge) Val() interface{} {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.value
 }
 
 // Update implements the Gauge behaviour and stores the value in the Recorder.
 func (g *RecorderGauge) Update(value interface{}) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	g.Value = value
+	g.value = value
 }
 
 // WithTags adds the passed tags to the Tags recorder map.
@@ -114,16 +120,22 @@ func (g *RecorderGauge) WithTag(key string, value interface{}) Gauge {
 // A RecorderEvent is a RecorderMetric that implements Event.
 type RecorderEvent struct {
 	RecorderMetric
-	Event string
+	event string
+	mu    sync.Mutex // protects the whole struct
+}
 
-	mu sync.Mutex // protects the whole struct
+// Event returns the event name in a thread-safe manner
+func (e *RecorderEvent) Event() string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.event
 }
 
 // Send implements the Event behaviour.
 func (e *RecorderEvent) Send() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	e.Event = e.name + "|"
+	e.event = e.name + "|"
 }
 
 // SendWithText implements the Event behaviour and stores the
@@ -131,7 +143,7 @@ func (e *RecorderEvent) Send() {
 func (e *RecorderEvent) SendWithText(text string) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	e.Event = e.name + "|" + text
+	e.event = e.name + "|" + text
 }
 
 // WithTags adds the passed tags to the Tags recorder map.
@@ -153,9 +165,23 @@ func (e *RecorderEvent) WithTag(key string, value interface{}) Event {
 // A RecorderTimer is a RecorderMetric that implements Timer.
 type RecorderTimer struct {
 	RecorderMetric
-	StartedTime time.Time
-	StoppedTime time.Time
+	startedTime time.Time
+	stoppedTime time.Time
 	mu          sync.Mutex // protects the whole struct
+}
+
+// StartedTime returns the time the timer was started in a thread-safe manner
+func (t *RecorderTimer) StartedTime() time.Time {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.startedTime
+}
+
+// StoppedTime returns the time the timer was stopped in a thread-safe manner
+func (t *RecorderTimer) StoppedTime() time.Time {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.stoppedTime
 }
 
 // Start the timer.
@@ -163,7 +189,7 @@ func (t *RecorderTimer) Start() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	t.StartedTime = time.Now()
+	t.startedTime = time.Now()
 }
 
 // Stop the timer.
@@ -171,7 +197,7 @@ func (t *RecorderTimer) Stop() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	t.StoppedTime = time.Now()
+	t.stoppedTime = time.Now()
 }
 
 // WithTags adds the passed tags to the Tags recorder map.
@@ -197,7 +223,7 @@ func (t *RecorderTimer) WithTag(key string, value interface{}) Timer {
 // RecorderHistogram is a RecorderMetrics that implements Histogram
 type RecorderHistogram struct {
 	RecorderMetric
-	Values []uint64
+	values []uint64
 	mu     sync.Mutex // protects the whole struct
 }
 
@@ -205,8 +231,7 @@ type RecorderHistogram struct {
 func (h *RecorderHistogram) Vals() []uint64 {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-
-	return h.Values
+	return h.values
 }
 
 // AddValue add the given value to the histogram
@@ -214,7 +239,7 @@ func (h *RecorderHistogram) AddValue(value uint64) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	h.Values = append(h.Values, value)
+	h.values = append(h.values, value)
 }
 
 // WithTags adds the passed tags to the Tags recorder map.

--- a/metrics/recorder_test.go
+++ b/metrics/recorder_test.go
@@ -54,41 +54,41 @@ func TestMetricsRecorder(t *testing.T) {
 		c.Inc()
 		c.Inc()
 
-		a.EqualValues(2, c.Value)
+		a.EqualValues(2, c.Val())
 
 		// test counter tags
 		a.Equal(c.Tags(), tags)
 		c.WithTags(moreTags...) // another way to set tags
 
 		c.Inc()
-		a.EqualValues(3, c.Value)
+		a.EqualValues(3, c.Val())
 
 		a.Equal(append(tags, moreTags...), c.Tags())
 
 		// test counter add from inc
 		c.Add(10)
-		a.EqualValues(13, c.Value)
+		a.EqualValues(13, c.Val())
 
 		// test counter add
 
 		c = r.Counter(metricName, tags...).(*metrics.RecorderCounter)
 		c.WithTags(tags...)
 		c.Add(10)
-		a.EqualValues(23, c.Value)
+		a.EqualValues(23, c.Val())
 
 		// test gauge
 		metricName = "gauge"
 		g := r.Gauge(metricName, tags...).(*metrics.RecorderGauge)
 		g.Update(math.Pi)
-		a.Equal(math.Pi, g.Value)
+		a.Equal(math.Pi, g.Val())
 		g.Update(math.E)
-		a.EqualValues(math.E, g.Value)
+		a.EqualValues(math.E, g.Val())
 
 		// test gauge tags
 		a.Equal(g.Tags(), tags)
 		g.WithTags(moreTags...) // another way to set tags
 		g.Update(math.Ln2)
-		a.EqualValues(math.Ln2, g.Value)
+		a.EqualValues(math.Ln2, g.Val())
 		a.EqualValues(g.Tags(), append(tags, moreTags...))
 		g.WithTag(lastTagKey, lastTagValue) // and another way to add one tag
 		a.Equal(g.Tags(), append(append(tags, moreTags...), lastTag))
@@ -97,15 +97,15 @@ func TestMetricsRecorder(t *testing.T) {
 		metricName = "event"
 		e := r.Event(metricName, tags...).(*metrics.RecorderEvent)
 		e.Send()
-		a.Equal("event|", e.Event)
+		a.Equal("event|", e.Event())
 		e.SendWithText("msg")
-		a.Equal("event|msg", e.Event)
+		a.Equal("event|msg", e.Event())
 
 		// test event tags
 		a.Equal(e.Tags(), tags)
 		e.WithTags(moreTags...) // another way to set tags
 		e.SendWithText("msg2")
-		a.Equal("event|msg2", e.Event)
+		a.Equal("event|msg2", e.Event())
 		a.Equal(append(tags, moreTags...), e.Tags())
 		e.WithTag(lastTagKey, lastTagValue) // and another way to add one tag
 		a.Equal(e.Tags(), append(append(tags, moreTags...), lastTag))
@@ -128,7 +128,7 @@ func TestMetricsRecorder(t *testing.T) {
 		h := r.Histogram(metricName, tags...).(*metrics.RecorderHistogram)
 		h.AddValue(42)
 		h.AddValue(666)
-		a.Equal([]uint64{42, 666}, h.Values)
+		a.Equal([]uint64{42, 666}, h.Vals())
 
 		// test histogram tags
 		a.Equal(h.Tags(), tags)
@@ -192,12 +192,12 @@ func TestRecorder_ConcurrentSafety(t *testing.T) {
 		}
 	}
 
-	a.EqualValues(2, c.Value)
-	a.EqualValues(123, g.Value)
-	a.WithinDuration(timer.StartedTime, timer.StoppedTime, time.Duration(time.Millisecond))
-	values := h.Values
+	a.EqualValues(2, c.Val())
+	a.EqualValues(123, g.Val())
+	a.WithinDuration(timer.StartedTime(), timer.StoppedTime(), time.Duration(time.Millisecond))
+	values := h.Vals()
 	sort.Slice(values, func(i, j int) bool {
 		return values[i] < values[j]
 	})
-	a.Equal([]uint64{42, 42, 666, 666}, h.Values)
+	a.Equal([]uint64{42, 42, 666, 666}, h.Vals())
 }

--- a/metrics/recorder_test.go
+++ b/metrics/recorder_test.go
@@ -54,41 +54,41 @@ func TestMetricsRecorder(t *testing.T) {
 		c.Inc()
 		c.Inc()
 
-		a.EqualValues(2, c.Val())
+		a.EqualValues(2, c.Value())
 
 		// test counter tags
 		a.Equal(c.Tags(), tags)
 		c.WithTags(moreTags...) // another way to set tags
 
 		c.Inc()
-		a.EqualValues(3, c.Val())
+		a.EqualValues(3, c.Value())
 
 		a.Equal(append(tags, moreTags...), c.Tags())
 
 		// test counter add from inc
 		c.Add(10)
-		a.EqualValues(13, c.Val())
+		a.EqualValues(13, c.Value())
 
 		// test counter add
 
 		c = r.Counter(metricName, tags...).(*metrics.RecorderCounter)
 		c.WithTags(tags...)
 		c.Add(10)
-		a.EqualValues(23, c.Val())
+		a.EqualValues(23, c.Value())
 
 		// test gauge
 		metricName = "gauge"
 		g := r.Gauge(metricName, tags...).(*metrics.RecorderGauge)
 		g.Update(math.Pi)
-		a.Equal(math.Pi, g.Val())
+		a.Equal(math.Pi, g.Value())
 		g.Update(math.E)
-		a.EqualValues(math.E, g.Val())
+		a.EqualValues(math.E, g.Value())
 
 		// test gauge tags
 		a.Equal(g.Tags(), tags)
 		g.WithTags(moreTags...) // another way to set tags
 		g.Update(math.Ln2)
-		a.EqualValues(math.Ln2, g.Val())
+		a.EqualValues(math.Ln2, g.Value())
 		a.EqualValues(g.Tags(), append(tags, moreTags...))
 		g.WithTag(lastTagKey, lastTagValue) // and another way to add one tag
 		a.Equal(g.Tags(), append(append(tags, moreTags...), lastTag))
@@ -128,7 +128,7 @@ func TestMetricsRecorder(t *testing.T) {
 		h := r.Histogram(metricName, tags...).(*metrics.RecorderHistogram)
 		h.AddValue(42)
 		h.AddValue(666)
-		a.Equal([]uint64{42, 666}, h.Vals())
+		a.Equal([]uint64{42, 666}, h.Values())
 
 		// test histogram tags
 		a.Equal(h.Tags(), tags)
@@ -192,12 +192,12 @@ func TestRecorder_ConcurrentSafety(t *testing.T) {
 		}
 	}
 
-	a.EqualValues(2, c.Val())
-	a.EqualValues(123, g.Val())
+	a.EqualValues(2, c.Value())
+	a.EqualValues(123, g.Value())
 	a.WithinDuration(timer.StartedTime(), timer.StoppedTime(), time.Duration(time.Millisecond))
-	values := h.Vals()
+	values := h.Values()
 	sort.Slice(values, func(i, j int) bool {
 		return values[i] < values[j]
 	})
-	a.Equal([]uint64{42, 42, 666, 666}, h.Vals())
+	a.Equal([]uint64{42, 42, 666, 666}, h.Values())
 }


### PR DESCRIPTION
Make all fields private and provide thread-safe accessors for all metrics recorder types.