### PR TITLE
Logx without file info option

### DIFF
--- a/logx/README.md
+++ b/logx/README.md
@@ -13,4 +13,3 @@ Features:
 Things not implemented yet:
 
 - colors
-- file and line

--- a/logx/logx_test.go
+++ b/logx/logx_test.go
@@ -17,6 +17,7 @@ func TestDefaultAndLogstashLogging(t *testing.T) {
 	rec := make(recorder, 1)
 	defaultLogger := logx.New(logx.WriterOpt(rec), logx.WithoutTimeOpt())
 	logstashLogger := logx.NewLogstash("mychan", "myprod", "myapp", logx.WriterOpt(rec), logx.WithoutTimeOpt())
+	logstashLoggerWithOriginalValues := logx.New(logx.MarshalerOpt(logx.NewLogstashMarshaler("mychan", "myprod", "myapp", logx.WithOriginalValueTypes())), logx.WriterOpt(rec), logx.WithoutTimeOpt())
 
 	hostname, _ := os.Hostname()
 
@@ -26,21 +27,24 @@ func TestDefaultAndLogstashLogging(t *testing.T) {
 		fields  []logx.Field
 		output  string
 	}{
-		{defaultLogger, "", nil, "DEBU  File: logx_test.go:48\n"},
-		{defaultLogger, "Test", nil, "DEBU Test File: logx_test.go:48\n"},
-		{defaultLogger, "Test 2", []logx.Field{logx.F("foo", "some stuff")}, "DEBU Test 2 FIELDS foo=some stuff File: logx_test.go:46\n"},
+		{defaultLogger, "", nil, "DEBU  File: logx_test.go:52\n"},
+		{defaultLogger, "Test", nil, "DEBU Test File: logx_test.go:52\n"},
+		{defaultLogger, "Test 2", []logx.Field{logx.F("foo", "some stuff")}, "DEBU Test 2 FIELDS foo=some stuff File: logx_test.go:50\n"},
 		// "type" is a logstash reserved keyword but just changes in logstash log
-		{defaultLogger, "Test 3", []logx.Field{logx.F("type", "val")}, "DEBU Test 3 FIELDS type=val File: logx_test.go:46\n"},
-		{defaultLogger, "Test 4", []logx.Field{logx.F("number", 111)}, "DEBU Test 4 FIELDS number=111 File: logx_test.go:46\n"},
-		{defaultLogger, "Test 5", []logx.Field{logx.F("type", "val"), logx.F("myint", 111), logx.F("myfloat", 3.1416)}, "DEBU Test 5 FIELDS type=val myint=111 myfloat=3.1416 File: logx_test.go:46\n"},
+		{defaultLogger, "Test 3", []logx.Field{logx.F("type", "val")}, "DEBU Test 3 FIELDS type=val File: logx_test.go:50\n"},
+		{defaultLogger, "Test 4", []logx.Field{logx.F("number", 111)}, "DEBU Test 4 FIELDS number=111 File: logx_test.go:50\n"},
+		{defaultLogger, "Test 5", []logx.Field{logx.F("type", "val"), logx.F("myint", 111), logx.F("myfloat", 3.1416)}, "DEBU Test 5 FIELDS type=val myint=111 myfloat=3.1416 File: logx_test.go:50\n"},
 
-		{logstashLogger, "", nil, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:48\",\"message\":\"\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
-		{logstashLogger, "Test", nil, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:48\",\"message\":\"Test\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
-		{logstashLogger, "Test 2", []logx.Field{logx.F("foo", "some stuff")}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:46\",\"foo\":\"some stuff\",\"message\":\"Test 2\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
+		{logstashLogger, "", nil, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:52\",\"message\":\"\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
+		{logstashLogger, "Test", nil, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:52\",\"message\":\"Test\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
+		{logstashLogger, "Test 2", []logx.Field{logx.F("foo", "some stuff")}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:50\",\"foo\":\"some stuff\",\"message\":\"Test 2\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
 		// "type" is a logstash reserved keyword but just changes in logstash log
-		{logstashLogger, "Test 3", []logx.Field{logx.F("type", "val")}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:46\",\"message\":\"Test 3\",\"product\":\"myprod\",\"severity\":\"DEBU\",\"typex\":\"val\"}\n", hostname)},
-		{logstashLogger, "Test 4", []logx.Field{logx.F("number", 111)}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:46\",\"message\":\"Test 4\",\"number\":\"111\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
-		{logstashLogger, "Test 5", []logx.Field{logx.F("type", "val"), logx.F("number", 111)}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:46\",\"message\":\"Test 5\",\"number\":\"111\",\"product\":\"myprod\",\"severity\":\"DEBU\",\"typex\":\"val\"}\n", hostname)},
+		{logstashLogger, "Test 3", []logx.Field{logx.F("type", "val")}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:50\",\"message\":\"Test 3\",\"product\":\"myprod\",\"severity\":\"DEBU\",\"typex\":\"val\"}\n", hostname)},
+		{logstashLogger, "Test 4", []logx.Field{logx.F("number", 111)}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:50\",\"message\":\"Test 4\",\"number\":\"111\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
+		{logstashLogger, "Test 5", []logx.Field{logx.F("type", "val"), logx.F("number", 111)}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:50\",\"message\":\"Test 5\",\"number\":\"111\",\"product\":\"myprod\",\"severity\":\"DEBU\",\"typex\":\"val\"}\n", hostname)},
+
+		{logstashLoggerWithOriginalValues, "Test With Original Values But No Fields", nil, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:52\",\"message\":\"Test With Original Values But No Fields\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
+		{logstashLoggerWithOriginalValues, "Test With Original Values", []logx.Field{logx.F("string", "hi there"), logx.F("number", 123), logx.F("array", []int{1, 2, 3}), logx.F("map", map[string]int{"foo": 123, "bar": 456})}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"array\":[1,2,3],\"channel\":\"mychan\",\"file\":\"logx_test.go:50\",\"map\":{\"bar\":456,\"foo\":123},\"message\":\"Test With Original Values\",\"number\":123,\"product\":\"myprod\",\"severity\":\"DEBU\",\"string\":\"hi there\"}\n", hostname)},
 	} {
 		if tc.fields != nil {
 			tc.logger.Debug(tc.message, tc.fields...)

--- a/logx/logx_test.go
+++ b/logx/logx_test.go
@@ -16,8 +16,10 @@ func TestDefaultAndLogstashLogging(t *testing.T) {
 
 	rec := make(recorder, 1)
 	defaultLogger := logx.New(logx.WriterOpt(rec), logx.WithoutTimeOpt())
+	defaultLoggerWithoutFileInfo := logx.New(logx.WriterOpt(rec), logx.WithoutTimeOpt(), logx.WithoutFileInfo())
 	logstashLogger := logx.NewLogstash("mychan", "myprod", "myapp", logx.WriterOpt(rec), logx.WithoutTimeOpt())
 	logstashLoggerWithOriginalValues := logx.New(logx.MarshalerOpt(logx.NewLogstashMarshaler("mychan", "myprod", "myapp", logx.WithOriginalValueTypes())), logx.WriterOpt(rec), logx.WithoutTimeOpt())
+	logstashLoggerWithoutFileInfo := logx.NewLogstash("mychan", "myprod", "myapp", logx.WriterOpt(rec), logx.WithoutTimeOpt(), logx.WithoutFileInfo())
 
 	hostname, _ := os.Hostname()
 
@@ -27,24 +29,24 @@ func TestDefaultAndLogstashLogging(t *testing.T) {
 		fields  []logx.Field
 		output  string
 	}{
-		{defaultLogger, "", nil, "DEBU  File: logx_test.go:52\n"},
-		{defaultLogger, "Test", nil, "DEBU Test File: logx_test.go:52\n"},
-		{defaultLogger, "Test 2", []logx.Field{logx.F("foo", "some stuff")}, "DEBU Test 2 FIELDS foo=some stuff File: logx_test.go:50\n"},
+		{defaultLogger, "", nil, "DEBU  File: logx_test.go:54\n"},
+		{defaultLogger, "Test", nil, "DEBU Test File: logx_test.go:54\n"},
+		{defaultLoggerWithoutFileInfo, "Test 2", []logx.Field{logx.F("foo", "some stuff")}, "DEBU Test 2 FIELDS foo=some stuff\n"},
 		// "type" is a logstash reserved keyword but just changes in logstash log
-		{defaultLogger, "Test 3", []logx.Field{logx.F("type", "val")}, "DEBU Test 3 FIELDS type=val File: logx_test.go:50\n"},
-		{defaultLogger, "Test 4", []logx.Field{logx.F("number", 111)}, "DEBU Test 4 FIELDS number=111 File: logx_test.go:50\n"},
-		{defaultLogger, "Test 5", []logx.Field{logx.F("type", "val"), logx.F("myint", 111), logx.F("myfloat", 3.1416)}, "DEBU Test 5 FIELDS type=val myint=111 myfloat=3.1416 File: logx_test.go:50\n"},
+		{defaultLogger, "Test 3", []logx.Field{logx.F("type", "val")}, "DEBU Test 3 FIELDS type=val File: logx_test.go:52\n"},
+		{defaultLogger, "Test 4", []logx.Field{logx.F("number", 111)}, "DEBU Test 4 FIELDS number=111 File: logx_test.go:52\n"},
+		{defaultLoggerWithoutFileInfo, "Test 5", []logx.Field{logx.F("type", "val"), logx.F("myint", 111), logx.F("myfloat", 3.1416)}, "DEBU Test 5 FIELDS type=val myint=111 myfloat=3.1416\n"},
 
-		{logstashLogger, "", nil, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:52\",\"message\":\"\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
-		{logstashLogger, "Test", nil, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:52\",\"message\":\"Test\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
-		{logstashLogger, "Test 2", []logx.Field{logx.F("foo", "some stuff")}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:50\",\"foo\":\"some stuff\",\"message\":\"Test 2\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
+		{logstashLogger, "", nil, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:54\",\"message\":\"\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
+		{logstashLogger, "Test", nil, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:54\",\"message\":\"Test\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
+		{logstashLoggerWithoutFileInfo, "Test 2", []logx.Field{logx.F("foo", "some stuff")}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"foo\":\"some stuff\",\"message\":\"Test 2\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
 		// "type" is a logstash reserved keyword but just changes in logstash log
-		{logstashLogger, "Test 3", []logx.Field{logx.F("type", "val")}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:50\",\"message\":\"Test 3\",\"product\":\"myprod\",\"severity\":\"DEBU\",\"typex\":\"val\"}\n", hostname)},
-		{logstashLogger, "Test 4", []logx.Field{logx.F("number", 111)}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:50\",\"message\":\"Test 4\",\"number\":\"111\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
-		{logstashLogger, "Test 5", []logx.Field{logx.F("type", "val"), logx.F("number", 111)}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:50\",\"message\":\"Test 5\",\"number\":\"111\",\"product\":\"myprod\",\"severity\":\"DEBU\",\"typex\":\"val\"}\n", hostname)},
+		{logstashLogger, "Test 3", []logx.Field{logx.F("type", "val")}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:52\",\"message\":\"Test 3\",\"product\":\"myprod\",\"severity\":\"DEBU\",\"typex\":\"val\"}\n", hostname)},
+		{logstashLogger, "Test 4", []logx.Field{logx.F("number", 111)}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:52\",\"message\":\"Test 4\",\"number\":\"111\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
+		{logstashLoggerWithoutFileInfo, "Test 5", []logx.Field{logx.F("type", "val"), logx.F("number", 111)}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"message\":\"Test 5\",\"number\":\"111\",\"product\":\"myprod\",\"severity\":\"DEBU\",\"typex\":\"val\"}\n", hostname)},
 
-		{logstashLoggerWithOriginalValues, "Test With Original Values But No Fields", nil, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:52\",\"message\":\"Test With Original Values But No Fields\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
-		{logstashLoggerWithOriginalValues, "Test With Original Values", []logx.Field{logx.F("string", "hi there"), logx.F("number", 123), logx.F("array", []int{1, 2, 3}), logx.F("map", map[string]int{"foo": 123, "bar": 456})}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"array\":[1,2,3],\"channel\":\"mychan\",\"file\":\"logx_test.go:50\",\"map\":{\"bar\":456,\"foo\":123},\"message\":\"Test With Original Values\",\"number\":123,\"product\":\"myprod\",\"severity\":\"DEBU\",\"string\":\"hi there\"}\n", hostname)},
+		{logstashLoggerWithOriginalValues, "Test With Original Values But No Fields", nil, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:54\",\"message\":\"Test With Original Values But No Fields\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
+		{logstashLoggerWithOriginalValues, "Test With Original Values", []logx.Field{logx.F("string", "hi there"), logx.F("number", 123), logx.F("array", []int{1, 2, 3}), logx.F("map", map[string]int{"foo": 123, "bar": 456})}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"array\":[1,2,3],\"channel\":\"mychan\",\"file\":\"logx_test.go:52\",\"map\":{\"bar\":456,\"foo\":123},\"message\":\"Test With Original Values\",\"number\":123,\"product\":\"myprod\",\"severity\":\"DEBU\",\"string\":\"hi there\"}\n", hostname)},
 	} {
 		if tc.fields != nil {
 			tc.logger.Debug(tc.message, tc.fields...)

--- a/logx/marshaler.go
+++ b/logx/marshaler.go
@@ -57,8 +57,10 @@ func (l HumanMarshaler) Marshal(entry *entry) ([]byte, error) {
 			_, _ = buffer.WriteString(fmt.Sprintf("%v", field.Value))
 		}
 	}
-	_, _ = buffer.WriteString(" ")
-	_, _ = buffer.WriteString(fmt.Sprintf("File: %s", entry.file))
+	if entry.file != "" {
+		_, _ = buffer.WriteString(" ")
+		_, _ = buffer.WriteString(fmt.Sprintf("File: %s", entry.file))
+	}
 	_, _ = buffer.WriteString("\n")
 	return buffer.Bytes(), nil
 }
@@ -114,7 +116,9 @@ func (l *LogstashMarshaler) Marshal(entry *entry) ([]byte, error) {
 	data["channel"] = l.channel
 	data["application"] = l.application
 	data["product"] = l.product
-	data["file"] = entry.file
+	if entry.file != "" {
+		data["file"] = entry.file
+	}
 	// rest
 	for _, field := range entry.fields {
 		var value interface{}

--- a/logx/options.go
+++ b/logx/options.go
@@ -6,11 +6,11 @@ import "io"
 type Option func(*options)
 
 type options struct {
-	marshaler     Marshaler
-	writer        io.Writer
-	level         Level
-	withoutTime   bool
-	fileSkipLevel int
+	marshaler       Marshaler
+	writer          io.Writer
+	level           Level
+	withoutTime     bool
+	withoutFileInfo bool
 }
 
 // MarshalerOpt is an option that changes the log marshaler.
@@ -41,9 +41,9 @@ func WithoutTimeOpt() Option {
 	}
 }
 
-// FileSkipLevel is an option that specify is the number of stack frames to ascend to get the calling file
-func FileSkipLevel(l int) Option {
+// WithoutFileInfo is an option that disables logging the file and line where the log was called.
+func WithoutFileInfo() Option {
 	return func(o *options) {
-		o.fileSkipLevel = l
+		o.withoutFileInfo = true
 	}
 }


### PR DESCRIPTION
Added an option to not log the file info -- handy for tests where you don't want to check for the file and line that generated the log.

Removed the option to set the fileSkipLevel as has no uses.

Review dce93f5 only.

- [x] Depends on #53 