### PR TITLE
Fix statsd encoder for DataDog agent 6.3

### DIFF
--- a/metrics/encoder.go
+++ b/metrics/encoder.go
@@ -20,20 +20,23 @@ func StatsDEncoder(name string, op Op, value interface{}, tags Tags, rate float6
 		ct[k] = fmt.Sprintf("%v:%v", t.Key, t.Value)
 	}
 	st := strings.Join(ct, ",")
+	if st != "" {
+		st = "|#" + st
+	}
 
 	switch op {
 	case OpCounterAdd:
-		return fmt.Sprintf("%s:%v|c|@%.4f|#%s\n", name, value, rate, st), nil
+		return fmt.Sprintf("%s:%v|c|@%.4f%s\n", name, value, rate, st), nil
 	case OpGaugeUpdate:
-		return fmt.Sprintf("%s:%v|g|@%.4f|#%s\n", name, value, rate, st), nil
+		return fmt.Sprintf("%s:%v|g|@%.4f%s\n", name, value, rate, st), nil
 	case OpHistogramUpdate:
-		return fmt.Sprintf("%s:%v|h|@%.4f|#%s\n", name, value, rate, st), nil
+		return fmt.Sprintf("%s:%v|h|@%.4f%s\n", name, value, rate, st), nil
 	case OpEventSend:
 		title := fmt.Sprintf("%v", name)
 		text := fmt.Sprintf("%v", value)
-		return fmt.Sprintf("_e{%d,%d}:%s|%s|#%s\n", len(title), len(text), title, text, st), nil
+		return fmt.Sprintf("_e{%d,%d}:%s|%s%s\n", len(title), len(text), title, text, st), nil
 	case OpTimerStop:
-		return fmt.Sprintf("%s:%v|ms|@%.4f|#%s\n", name, value, rate, st), nil
+		return fmt.Sprintf("%s:%v|ms|@%.4f%s\n", name, value, rate, st), nil
 	}
 
 	return "", fmt.Errorf("statsd encoder: operation %v not supported", op)

--- a/metrics/encoder_test.go
+++ b/metrics/encoder_test.go
@@ -17,27 +17,27 @@ func TestStatsDEncoder(t *testing.T) {
 		rate  float64
 		out   string
 	}{
-		{"x", metrics.OpCounterAdd, 123, nil, 1, "x:123|c|@1.0000|#\n"},
-		{"x", metrics.OpCounterAdd, time.Second, nil, 1, "x:1s|c|@1.0000|#\n"},
-		{"x", metrics.OpCounterAdd, time.Millisecond, nil, 1, "x:1ms|c|@1.0000|#\n"},
-		{"x", metrics.OpCounterAdd, time.Nanosecond * 5, nil, 1, "x:5ns|c|@1.0000|#\n"},
-		{"x", metrics.OpCounterAdd, (time.Nanosecond * 5).Nanoseconds(), nil, 1, "x:5|c|@1.0000|#\n"},
-		{"x", metrics.OpGaugeUpdate, 123, nil, 1, "x:123|g|@1.0000|#\n"},
-		{"x", metrics.OpGaugeUpdate, 1.23, nil, 1, "x:1.23|g|@1.0000|#\n"},
-		{"x", metrics.OpGaugeUpdate, -123, nil, 1, "x:-123|g|@1.0000|#\n"},
-		{"x", metrics.OpGaugeUpdate, -123, nil, 0.250, "x:-123|g|@0.2500|#\n"},
-		{"x", metrics.OpHistogramUpdate, 123, nil, 0.250, "x:123|h|@0.2500|#\n"},
-		{"x", metrics.OpHistogramUpdate, 123.456, nil, 0.250, "x:123.456|h|@0.2500|#\n"},
-		{"abc_xyz.sp.com", metrics.OpHistogramUpdate, 123.456, nil, 0.250, "abc_xyz.sp.com:123.456|h|@0.2500|#\n"},
+		{"x", metrics.OpCounterAdd, 123, nil, 1, "x:123|c|@1.0000\n"},
+		{"x", metrics.OpCounterAdd, time.Second, nil, 1, "x:1s|c|@1.0000\n"},
+		{"x", metrics.OpCounterAdd, time.Millisecond, nil, 1, "x:1ms|c|@1.0000\n"},
+		{"x", metrics.OpCounterAdd, time.Nanosecond * 5, nil, 1, "x:5ns|c|@1.0000\n"},
+		{"x", metrics.OpCounterAdd, (time.Nanosecond * 5).Nanoseconds(), nil, 1, "x:5|c|@1.0000\n"},
+		{"x", metrics.OpGaugeUpdate, 123, nil, 1, "x:123|g|@1.0000\n"},
+		{"x", metrics.OpGaugeUpdate, 1.23, nil, 1, "x:1.23|g|@1.0000\n"},
+		{"x", metrics.OpGaugeUpdate, -123, nil, 1, "x:-123|g|@1.0000\n"},
+		{"x", metrics.OpGaugeUpdate, -123, nil, 0.250, "x:-123|g|@0.2500\n"},
+		{"x", metrics.OpHistogramUpdate, 123, nil, 0.250, "x:123|h|@0.2500\n"},
+		{"x", metrics.OpHistogramUpdate, 123.456, nil, 0.250, "x:123.456|h|@0.2500\n"},
+		{"abc_xyz.sp.com", metrics.OpHistogramUpdate, 123.456, nil, 0.250, "abc_xyz.sp.com:123.456|h|@0.2500\n"},
 
 		{"x", metrics.OpCounterAdd, 123, []metrics.Tag{{Key: "x", Value: "1"}}, 1, "x:123|c|@1.0000|#x:1\n"},
 		{"x", metrics.OpCounterAdd, 123, []metrics.Tag{{Key: "x", Value: "1"}, {Key: "y", Value: 2}}, 1, "x:123|c|@1.0000|#x:1,y:2\n"},
 		{"x", metrics.OpCounterAdd, 123, []metrics.Tag{{Key: "x", Value: "1"}, {Key: "y", Value: 2}, {Key: "z", Value: "value"}}, 1, "x:123|c|@1.0000|#x:1,y:2,z:value\n"},
 
-		{"event title", metrics.OpEventSend, "event text", nil, 1, "_e{11,10}:event title|event text|#\n"},
+		{"event title", metrics.OpEventSend, "event text", nil, 1, "_e{11,10}:event title|event text\n"},
 		{"event title", metrics.OpEventSend, "event text", []metrics.Tag{{Key: "x", Value: "1"}, {Key: "y", Value: 2}, {Key: "z", Value: "value"}}, 1, "_e{11,10}:event title|event text|#x:1,y:2,z:value\n"},
 
-		{"timer", metrics.OpTimerStop, 123.321, nil, 1, "timer:123.321|ms|@1.0000|#\n"},
+		{"timer", metrics.OpTimerStop, 123.321, nil, 1, "timer:123.321|ms|@1.0000\n"},
 	}
 
 	for _, test := range tests {
@@ -87,5 +87,5 @@ func TestNamespacedEncoder(t *testing.T) {
 	out, err := ne("test", metrics.OpCounterAdd, 123, nil, 1)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "test_namespace.test:123|c|@1.0000|#\n", out)
+	assert.Equal(t, "test_namespace.test:123|c|@1.0000\n", out)
 }

--- a/metrics/publisher_test.go
+++ b/metrics/publisher_test.go
@@ -93,7 +93,7 @@ func TestPublisherFlushMetricsToRealUDPServer(t *testing.T) {
 	line, err := reader.ReadString('\n')
 
 	a.NoError(err)
-	a.Equal("test:123|c|@1.0000|#\n", line)
+	a.Equal("test:123|c|@1.0000\n", line)
 }
 
 func TestTimerEvent(t *testing.T) {
@@ -121,7 +121,7 @@ func TestTimerEvent(t *testing.T) {
 
 	a.NoError(err)
 	a.Contains(line, "test:")
-	a.Contains(line, "|ms|@1.0000|#\n")
+	a.Contains(line, "|ms|@1.0000\n")
 }
 
 func TestPublisherHistogram(t *testing.T) {
@@ -147,11 +147,11 @@ func TestPublisherHistogram(t *testing.T) {
 
 	line, err := reader.ReadString('\n')
 	a.NoError(err)
-	a.Equal("test:42|h|@1.0000|#\n", line)
+	a.Equal("test:42|h|@1.0000\n", line)
 
 	line, err = reader.ReadString('\n')
 	a.NoError(err)
-	a.Equal("test:666|h|@1.0000|#\n", line)
+	a.Equal("test:666|h|@1.0000\n", line)
 }
 
 type recorder chan string


### PR DESCRIPTION
The DataDog agent v6.3 is choking with lines ending with the tags token, but with no tags. It simply won't report metrics affected.

In this PR we remove the tags component of the string if there are none.