### PR TITLE
Metrics for DataDog in AWS Lambda functions

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -27,3 +27,11 @@ Dogstatsd (Datadog agent) is a statsd backend server, so you can send custom met
 protocol.
 
 To integrate with Datadog agent, just provide an UDP network connection for the publisher `io.writer`. 
+
+## Integration with DataDog in AWS Lambda functions
+
+A publisher and an encoder are provided to update DataDog metrics from within the execution of AWS Lambda functions.
+
+Only counters, gauges and histograms are supported by DataDog at the moment.
+
+Find more info on [how the integration works](https://docs.datadoghq.com/integrations/amazon_lambda/) in the DataDog site.

--- a/metrics/encoder_internal_test.go
+++ b/metrics/encoder_internal_test.go
@@ -1,0 +1,55 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"errors"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatDataDogLambdaMetric(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	now := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	var tests = []struct {
+		name  string
+		op    Op
+		value interface{}
+		tags  Tags
+		rate  float64
+		out   string
+	}{
+		{"x", OpCounterAdd, 123, nil, 1, "MONITORING|0|123|count|x|#\n"},
+		{"x", OpCounterAdd, time.Second, nil, 1, "MONITORING|0|1s|count|x|#\n"},
+		{"x", OpCounterAdd, time.Millisecond, nil, 1, "MONITORING|0|1ms|count|x|#\n"},
+		{"x", OpCounterAdd, time.Nanosecond * 5, nil, 1, "MONITORING|0|5ns|count|x|#\n"},
+		{"x", OpCounterAdd, (time.Nanosecond * 5).Nanoseconds(), nil, 1, "MONITORING|0|5|count|x|#\n"},
+		{"x", OpGaugeUpdate, 123, nil, 1, "MONITORING|0|123|gauge|x|#\n"},
+		{"x", OpGaugeUpdate, 1.23, nil, 1, "MONITORING|0|1.23|gauge|x|#\n"},
+		{"x", OpGaugeUpdate, -123, nil, 1, "MONITORING|0|-123|gauge|x|#\n"},
+		{"x", OpGaugeUpdate, -123, nil, 0.250, "MONITORING|0|-123|gauge|x|#\n"},
+		{"x", OpHistogramUpdate, 123, nil, 0.250, "MONITORING|0|123|histogram|x|#\n"},
+		{"x", OpHistogramUpdate, 123.456, nil, 0.250, "MONITORING|0|123.456|histogram|x|#\n"},
+		{"abc_xyz.sp.com", OpHistogramUpdate, 123.456, nil, 0.250, "MONITORING|0|123.456|histogram|abc_xyz.sp.com|#\n"},
+
+		{"x", OpCounterAdd, 123, []Tag{{Key: "x", Value: "1"}}, 1, "MONITORING|0|123|count|x|#x:1\n"},
+		{"x", OpCounterAdd, 123, []Tag{{Key: "x", Value: "1"}, {Key: "y", Value: 2}}, 1, "MONITORING|0|123|count|x|#x:1,y:2\n"},
+		{"x", OpCounterAdd, 123, []Tag{{Key: "x", Value: "1"}, {Key: "y", Value: 2}, {Key: "z", Value: "value"}}, 1, "MONITORING|0|123|count|x|#x:1,y:2,z:value\n"},
+	}
+
+	for _, test := range tests {
+		out, err := formatDataDogLambdaMetric(test.name, test.op, test.value, test.tags, now)
+		a.NoError(err)
+		a.Equal(test.out, out)
+	}
+
+	_, err := formatDataDogLambdaMetric("some.metric", OpEventSend, "event message", Tags{}, time.Now())
+	a.Equal(errors.New(`datadog-lambda encoder: operation "event send" not supported`), err)
+
+	_, err = formatDataDogLambdaMetric("some.metric", OpTimerStop, now, Tags{}, time.Now())
+	a.Equal(errors.New(`datadog-lambda encoder: operation "timer stop" not supported`), err)
+}

--- a/metrics/encoder_internal_test.go
+++ b/metrics/encoder_internal_test.go
@@ -1,10 +1,9 @@
 package metrics
 
 import (
+	"errors"
 	"testing"
 	"time"
-
-	"errors"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/metrics/encoder_test.go
+++ b/metrics/encoder_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestStatsDEncoder(t *testing.T) {
+	t.Parallel()
+
 	var tests = []struct {
 		name  string
 		op    metrics.Op
@@ -48,6 +50,8 @@ func TestStatsDEncoder(t *testing.T) {
 }
 
 func TestLibratoStatsDEncoder(t *testing.T) {
+	t.Parallel()
+
 	var tests = []struct {
 		name  string
 		op    metrics.Op

--- a/metrics/factory_test.go
+++ b/metrics/factory_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestNewPublisherWithDSN(t *testing.T) {
-	assert := assert.New(t)
+	t.Parallel()
+	a := assert.New(t)
 
 	var cancelFuncs []context.CancelFunc
 	for _, testCase := range []struct {
@@ -23,16 +24,19 @@ func TestNewPublisherWithDSN(t *testing.T) {
 		{"datadog://", false},
 		{"datadog://?namespace=my_namespace", true},
 		{"datadog://?namespace=my_namespace&gostats=false", true},
+		{"datadog-lambda://", false},
+		{"datadog-lambda://?namespace=my_namespace", true},
+		{"datadog-lambda://?namespace=my_namespace&gostats=false", true},
 	} {
 		if testCase.isValid {
 			publisher, runner := metrics.NewMetricsRunnerFromDSN(testCase.DSN)
-			assert.NotNil(publisher)
-			assert.NotNil(runner)
+			a.NotNil(publisher)
+			a.NotNil(runner)
 			ctx, cancel := context.WithCancel(context.Background())
 			cancelFuncs = append(cancelFuncs, cancel)
 			go runner.Run(ctx)
 		} else {
-			assert.Panics(func() { metrics.NewMetricsRunnerFromDSN(testCase.DSN) })
+			a.Panics(func() { metrics.NewMetricsRunnerFromDSN(testCase.DSN) })
 		}
 	}
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"strconv"
 	"time"
 )
 
@@ -23,6 +24,17 @@ const (
 	OpEventSend
 	OpTimerStop
 )
+
+func (op Op) String() string {
+	name := []string{"counter add", "gauge update", "histogram update", "event send", "timer stop"}
+	i := uint8(op)
+	switch {
+	case i <= uint8(OpTimerStop):
+		return name[i]
+	default:
+		return strconv.Itoa(int(i))
+	}
+}
 
 // Tag is a key/value pair associated with an observation for a specific
 // metric. Tags may be ignored by implementations.

--- a/metrics/publisher.go
+++ b/metrics/publisher.go
@@ -125,6 +125,11 @@ func NewDataDog(opts ...DatadogOption) *Publisher {
 	return NewPublisher(client, StatsDEncoder, options.flushInterval, nil)
 }
 
+// NewDataDogLambda returns a publisher that satisfies DataDog metrics writing for AWS Lambda.
+func NewDataDogLambda() *Publisher {
+	return NewPublisher(os.Stdout, DataDogLambdaEncoder, FlushEvery3s, nil)
+}
+
 // Counter returns a new counter with the provided name and tags
 func (p *Publisher) Counter(name string, tags ...Tag) Counter {
 	return &publisherCounter{publisherMetric{name: name, tags: tags, nf: p.notify}}


### PR DESCRIPTION
This PR introduces a new producer and encoder to update DataDog metrics from within AWS Lambda functions.

DD doc: https://docs.datadoghq.com/integrations/amazon_lambda/