### PR TITLE
Customizable file skip level

### DIFF
--- a/logx/logx.go
+++ b/logx/logx.go
@@ -72,6 +72,7 @@ type Log struct {
 	level           Level
 	withoutTime     bool
 	withoutFileInfo bool
+	fileSkipLevel   int
 }
 
 // Debug logs a message at level Debug
@@ -97,7 +98,7 @@ func (l *Log) log(level Level, message string, fields ...Field) {
 
 	var fi string
 	if !l.withoutFileInfo {
-		fi = fileInfo()
+		fi = fileInfo(l.fileSkipLevel)
 	}
 
 	entry := &entry{
@@ -133,6 +134,9 @@ func NewLogstash(channel, product, application string, opts ...Option) *Log {
 	if options.level == 0 {
 		options.level = DefaultMinLevel
 	}
+	if options.fileSkipLevel == 0 {
+		options.fileSkipLevel = defaultFileSkipLevel
+	}
 
 	return loggerFromOptions(options)
 }
@@ -152,6 +156,9 @@ func New(opts ...Option) *Log {
 	}
 	if options.level == 0 {
 		options.level = DefaultMinLevel
+	}
+	if options.fileSkipLevel == 0 {
+		options.fileSkipLevel = defaultFileSkipLevel
 	}
 
 	return loggerFromOptions(options)
@@ -173,6 +180,9 @@ func NewDummy(opts ...Option) *Log {
 	if options.level == 0 {
 		options.level = DefaultMinLevel
 	}
+	if options.fileSkipLevel == 0 {
+		options.fileSkipLevel = defaultFileSkipLevel
+	}
 
 	return loggerFromOptions(options)
 }
@@ -184,11 +194,12 @@ func loggerFromOptions(opts *options) *Log {
 		level:           opts.level,
 		withoutTime:     opts.withoutTime,
 		withoutFileInfo: opts.withoutFileInfo,
+		fileSkipLevel:   opts.fileSkipLevel,
 	}
 }
 
-func fileInfo() string {
-	_, file, line, ok := runtime.Caller(defaultFileSkipLevel)
+func fileInfo(fileSkipLevel int) string {
+	_, file, line, ok := runtime.Caller(fileSkipLevel)
 	if !ok {
 		file = "<???>"
 		line = 1

--- a/logx/logx.go
+++ b/logx/logx.go
@@ -134,9 +134,6 @@ func NewLogstash(channel, product, application string, opts ...Option) *Log {
 	if options.level == 0 {
 		options.level = DefaultMinLevel
 	}
-	if options.fileSkipLevel == 0 {
-		options.fileSkipLevel = defaultFileSkipLevel
-	}
 
 	return loggerFromOptions(options)
 }
@@ -156,9 +153,6 @@ func New(opts ...Option) *Log {
 	}
 	if options.level == 0 {
 		options.level = DefaultMinLevel
-	}
-	if options.fileSkipLevel == 0 {
-		options.fileSkipLevel = defaultFileSkipLevel
 	}
 
 	return loggerFromOptions(options)
@@ -180,9 +174,6 @@ func NewDummy(opts ...Option) *Log {
 	if options.level == 0 {
 		options.level = DefaultMinLevel
 	}
-	if options.fileSkipLevel == 0 {
-		options.fileSkipLevel = defaultFileSkipLevel
-	}
 
 	return loggerFromOptions(options)
 }
@@ -194,7 +185,7 @@ func loggerFromOptions(opts *options) *Log {
 		level:           opts.level,
 		withoutTime:     opts.withoutTime,
 		withoutFileInfo: opts.withoutFileInfo,
-		fileSkipLevel:   opts.fileSkipLevel,
+		fileSkipLevel:   defaultFileSkipLevel + opts.additionalFileSkipLevel,
 	}
 }
 

--- a/logx/logx_test.go
+++ b/logx/logx_test.go
@@ -60,7 +60,7 @@ func TestDefaultAndLogstashLogging(t *testing.T) {
 func TestLoggingWithCustomSkipLevel(t *testing.T) {
 	assert := assert.New(t)
 	rec := make(recorder, 1)
-	defaultLogger := logx.New(logx.WriterOpt(rec), logx.WithoutTimeOpt(), logx.FileSkipLevel(4))
+	defaultLogger := logx.New(logx.WriterOpt(rec), logx.WithoutTimeOpt(), logx.AdditionalFileSkipLevel(1))
 
 	log(defaultLogger, "Test")
 	assert.Equal("DEBU Test File: logx_test.go:65\n", <-rec)

--- a/logx/logx_test.go
+++ b/logx/logx_test.go
@@ -57,6 +57,19 @@ func TestDefaultAndLogstashLogging(t *testing.T) {
 	}
 }
 
+func TestLoggingWithCustomSkipLevel(t *testing.T) {
+	assert := assert.New(t)
+	rec := make(recorder, 1)
+	defaultLogger := logx.New(logx.WriterOpt(rec), logx.WithoutTimeOpt(), logx.FileSkipLevel(4))
+
+	log(defaultLogger, "Test")
+	assert.Equal("DEBU Test File: logx_test.go:65\n", <-rec)
+}
+
+func log(logger logx.Logger, message string) {
+	logger.Debug(message)
+}
+
 func TestLogLevel(t *testing.T) {
 	assert := assert.New(t)
 

--- a/logx/options.go
+++ b/logx/options.go
@@ -6,12 +6,12 @@ import "io"
 type Option func(*options)
 
 type options struct {
-	marshaler       Marshaler
-	writer          io.Writer
-	level           Level
-	withoutTime     bool
-	withoutFileInfo bool
-	fileSkipLevel   int
+	marshaler               Marshaler
+	writer                  io.Writer
+	level                   Level
+	withoutTime             bool
+	withoutFileInfo         bool
+	additionalFileSkipLevel int
 }
 
 // MarshalerOpt is an option that changes the log marshaler.
@@ -49,9 +49,9 @@ func WithoutFileInfo() Option {
 	}
 }
 
-// FileSkipLevel is an option that lets you customize how many levels up you want to go to find the file doing the log.
-func FileSkipLevel(l int) Option {
+// AdditionalFileSkipLevel is an option that lets you go more levels up to find the file & line doing the log.
+func AdditionalFileSkipLevel(l int) Option {
 	return func(o *options) {
-		o.fileSkipLevel = l
+		o.additionalFileSkipLevel = l
 	}
 }

--- a/logx/options.go
+++ b/logx/options.go
@@ -11,6 +11,7 @@ type options struct {
 	level           Level
 	withoutTime     bool
 	withoutFileInfo bool
+	fileSkipLevel   int
 }
 
 // MarshalerOpt is an option that changes the log marshaler.
@@ -45,5 +46,12 @@ func WithoutTimeOpt() Option {
 func WithoutFileInfo() Option {
 	return func(o *options) {
 		o.withoutFileInfo = true
+	}
+}
+
+// FileSkipLevel is an option that lets you customize how many levels up you want to go to find the file doing the log.
+func FileSkipLevel(l int) Option {
+	return func(o *options) {
+		o.fileSkipLevel = l
 	}
 }


### PR DESCRIPTION
# Context
If the logger is wrapped inside a function, we currently have no way to see the file which originated the log. 
# Solution
This adds the possibility to see it by customizing the skip level for loggers which are meant to be used via a wrapper function.