### PR TITLE
Fix build for latest go release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 
 go:
     - '1.10'
-    - 'tip'
+    - '1.x'
 
 env:
   - DEP_VERSION="0.4.1"

--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ install-tools:
 lint:
 	golangci-lint run
 
-ci-check: lint test-ci
+ci-check: test-ci

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SOURCES=$(shell find . -name "*.go" | grep -v vendor/)
 PACKAGES=$(shell go list ./...)
+LINTER_VERSION=1.16.0
 
 deps:
 	go get -t -u ./...
@@ -16,7 +17,7 @@ test-ci:
 install-tools:
 	go get github.com/mattn/goveralls
 	go get golang.org/x/tools/cmd/cover
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.15.0
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v$(LINTER_VERSION)
 
 lint:
 	golangci-lint run


### PR DESCRIPTION
# Context
Build is still failing for the latest go version
# Solution
Updated the travis.yml to use `1.x` (latest version of the 1 branch) instead of `tip` (undocumented feature of travis)

Also includes updating the linter tools to 1.16.0