### PR TITLE
Adds golangci linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,20 @@
 linters:
     enable:
         - golint
-        - goimports
         - interfacer
+        - unconvert
+        - goconst
+        - maligned
+        - misspell
+        - prealloc
+        - gocritic
+
+linters-settings:
+    errcheck:
+        # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
+        # default is false: such cases aren't reported by default.
+        check-type-assertions: true
+
+    maligned:
+        # print struct with more effective memory layout or not, false by default
+        suggest-new: true

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,35 @@
-SOURCES=$(shell find . -name "*.go" | grep -v vendor/)
 PACKAGES=$(shell go list ./...)
 LINTER_VERSION=1.18.0
 
-deps:
-	go get -t -u ./...
+lint:
+	goimports -w .
+	go mod verify
+	golangci-lint run
+.PHONY: lint
 
 test:
 	go test ./...
+.PHONY: test
 
-test-ci:
+ci-lint:
+	fgt goimports -l .
+	go mod verify
+	golangci-lint run
+.PHONY: ci-lint
+
+ci-test:
 	echo "mode: count" > coverage-all.out
 	$(foreach pkg,$(PACKAGES),\
 		GORACE="halt_on_error=1" go test -v -race -cover -coverprofile=coverage.out $(pkg) || exit 1;\
 		tail -n +2 coverage.out >> coverage-all.out;)
+.PHONY: ci-test
+
+ci-check: ci-lint ci-test
+.PHONY: ci-check
 
 install-tools:
-	go get golang.org/x/tools/cmd/cover
+	go get -u github.com/GeertJohan/fgt
+	go get -u golang.org/x/tools/cmd/cover
+	go get -u golang.org/x/tools/cmd/goimports
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v$(LINTER_VERSION)
-
-lint:
-	golangci-lint run
-	go mod verify
-
-ci-check: test-ci
+.PHONY: install-tools

--- a/httpx/instrument_test.go
+++ b/httpx/instrument_test.go
@@ -51,7 +51,7 @@ func TestInstrument_RequestsDuration(t *testing.T) {
 
 		h.ServeHTTP(w, r)
 
-		timer := recorder.Get("http.request_duration").(*metrics.RecorderTimer)
+		timer, _ := recorder.Get("http.request_duration").(*metrics.RecorderTimer)
 		a.WithinDuration(timer.StartedTime(), timer.StoppedTime(), deltaTime)
 		a.Len(timer.Tags(), tc.expectedTags)
 		a.Equal(http.StatusNoContent, w.Code)

--- a/metrics/factory.go
+++ b/metrics/factory.go
@@ -9,9 +9,9 @@ import (
 
 // NewMetricsRunnerFromDSN creates a new metrics publisher and returns its Metrics
 // and Runner from a DSN configuration. If the configuration is not valid it panics.
-func NewMetricsRunnerFromDSN(DSN string) (Metrics, contextx.Runner) {
+func NewMetricsRunnerFromDSN(dsn string) (Metrics, contextx.Runner) {
 	// param validation
-	URL, err := url.Parse(DSN)
+	URL, err := url.Parse(dsn)
 	if err != nil {
 		panic(err)
 	}

--- a/metrics/recorder_test.go
+++ b/metrics/recorder_test.go
@@ -50,7 +50,7 @@ func TestMetricsRecorder(t *testing.T) {
 
 		// test counter inc
 		metricName := "counter"
-		c := r.Counter(metricName, tags...).(*metrics.RecorderCounter)
+		c, _ := r.Counter(metricName, tags...).(*metrics.RecorderCounter)
 		c.Inc()
 		c.Inc()
 
@@ -71,14 +71,14 @@ func TestMetricsRecorder(t *testing.T) {
 
 		// test counter add
 
-		c = r.Counter(metricName, tags...).(*metrics.RecorderCounter)
+		c, _ = r.Counter(metricName, tags...).(*metrics.RecorderCounter)
 		c.WithTags(tags...)
 		c.Add(10)
 		a.EqualValues(23, c.Value())
 
 		// test gauge
 		metricName = "gauge"
-		g := r.Gauge(metricName, tags...).(*metrics.RecorderGauge)
+		g, _ := r.Gauge(metricName, tags...).(*metrics.RecorderGauge)
 		g.Update(math.Pi)
 		a.Equal(math.Pi, g.Value())
 		g.Update(math.E)
@@ -95,7 +95,7 @@ func TestMetricsRecorder(t *testing.T) {
 
 		// test event
 		metricName = "event"
-		e := r.Event(metricName, tags...).(*metrics.RecorderEvent)
+		e, _ := r.Event(metricName, tags...).(*metrics.RecorderEvent)
 		e.Send()
 		a.Equal("event|", e.Event())
 		e.SendWithText("msg")
@@ -125,7 +125,7 @@ func TestMetricsRecorder(t *testing.T) {
 
 		// test Histogram
 		metricName = "histogram"
-		h := r.Histogram(metricName, tags...).(*metrics.RecorderHistogram)
+		h, _ := r.Histogram(metricName, tags...).(*metrics.RecorderHistogram)
 		h.AddValue(42)
 		h.AddValue(666)
 		a.Equal([]uint64{42, 666}, h.Values())
@@ -153,30 +153,30 @@ func TestRecorder_ConcurrentSafety(t *testing.T) {
 	r.Histogram("histogram")
 
 	thread := func() {
-		c := r.Get("counter").(*metrics.RecorderCounter)
+		c, _ := r.Get("counter").(*metrics.RecorderCounter)
 		c.Inc()
 
-		g := r.Get("gauge").(*metrics.RecorderGauge)
+		g, _ := r.Get("gauge").(*metrics.RecorderGauge)
 		g.Update(123)
 
-		timer := r.Get("timer").(*metrics.RecorderTimer)
+		timer, _ := r.Get("timer").(*metrics.RecorderTimer)
 		timer.Start()
 		timer.Stop()
 
-		e := r.Get("event").(*metrics.RecorderEvent)
+		e, _ := r.Get("event").(*metrics.RecorderEvent)
 		e.SendWithText("life")
 
-		h := r.Get("histogram").(*metrics.RecorderHistogram)
+		h, _ := r.Get("histogram").(*metrics.RecorderHistogram)
 		h.AddValue(42)
 		h.AddValue(666)
 
 		ch <- true
 	}
 
-	c := r.Get("counter").(*metrics.RecorderCounter)
-	g := r.Get("gauge").(*metrics.RecorderGauge)
-	timer := r.Get("timer").(*metrics.RecorderTimer)
-	h := r.Get("histogram").(*metrics.RecorderHistogram)
+	c, _ := r.Get("counter").(*metrics.RecorderCounter)
+	g, _ := r.Get("gauge").(*metrics.RecorderGauge)
+	timer, _ := r.Get("timer").(*metrics.RecorderTimer)
+	h, _ := r.Get("histogram").(*metrics.RecorderHistogram)
 
 	go thread()
 	go thread()
@@ -194,7 +194,7 @@ func TestRecorder_ConcurrentSafety(t *testing.T) {
 
 	a.EqualValues(2, c.Value())
 	a.EqualValues(123, g.Value())
-	a.WithinDuration(timer.StartedTime(), timer.StoppedTime(), time.Duration(time.Millisecond))
+	a.WithinDuration(timer.StartedTime(), timer.StoppedTime(), time.Millisecond)
 	a.Equal(timer.StoppedTime().Sub(timer.StartedTime()), timer.Duration())
 	values := h.Values()
 	sort.Slice(values, func(i, j int) bool {

--- a/multierror/multierror_test.go
+++ b/multierror/multierror_test.go
@@ -54,7 +54,7 @@ func TestWalk(t *testing.T) {
 	e3 := errors.New("e3")
 
 	var s string
-	walker := func(e error) { s = s + e.Error() }
+	walker := func(e error) { s += e.Error() }
 
 	err := multierror.Append(e1, e2, e3)
 	multierror.Walk(err, walker)


### PR DESCRIPTION
Adds more golangci linters and applies code fixes for newly detected issues.

Switches to the binary for `goimports` instead of the linter provided by golangci due to its output being misguiding. 

Makes the build fail in CI if `goimports` finds any formatting difference.