### PR TITLE
Remove SIGUSR1 for Windows compatibility

### DIFF
--- a/contextx/posixsignal.go
+++ b/contextx/posixsignal.go
@@ -33,13 +33,13 @@ func signalsAdapter(c chan os.Signal) AdapterFunc {
 			// Bear in mind that SIGKILL and SIGSTOP cannot be trapped, see
 			// https://goo.gl/5gvRrN. Also know that pressing <ctrl-c> from CLI
 			// will make the process receive a SIGINT.
-			signal.Notify(c, syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR1, syscall.SIGHUP)
+			signal.Notify(c, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 
 			for {
 				select {
 				case signal := <-c:
 					switch signal {
-					case syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR1:
+					case syscall.SIGINT, syscall.SIGTERM:
 						cancel()
 
 						// TODO: How do we wait until everybody cancelled ?

--- a/contextx/posixsignal_test.go
+++ b/contextx/posixsignal_test.go
@@ -18,7 +18,6 @@ func TestContextCancellationWhenSignalsAreNotified(t *testing.T) {
 		isCanceled  bool
 		description string
 	}{
-		{syscall.SIGUSR1, true, "use SIGUSR1 instead of SIGKILL/SIGTERM otherwise the test process is killed"},
 		{syscall.SIGHUP, false, "config signal handling does nothing, so context won't be canceled"},
 		{syscall.SIGWINCH, false, "this signal is not even handled, same thing than sighup"},
 	}


### PR DESCRIPTION
Windows supports just a subset of POSIX and `SIGUSR1` is not among the supported things