### PR TITLE
logx: error severity

### DIFF
--- a/grpcx/server.go
+++ b/grpcx/server.go
@@ -51,7 +51,7 @@ func WithRequestResponseLogs(l logx.Logger) grpc.UnaryServerInterceptor {
 			})
 		}
 
-		l.Info("gRPC Message", fields...)
+		l.Debug("gRPC Message", fields...)
 
 		return resp, err
 	}
@@ -83,7 +83,7 @@ func WithErrorLogs(l logx.Logger, options ...ErrorLogsOption) grpc.UnaryServerIn
 				if inCodeList(errCode, logOptions.debugLevelCodes) {
 					l.Debug("gRPC Error", fields...)
 				} else {
-					l.Info("gRPC Error", fields...)
+					l.Error("gRPC Error", fields...)
 				}
 			}
 		}

--- a/grpcx/server.go
+++ b/grpcx/server.go
@@ -51,7 +51,7 @@ func WithRequestResponseLogs(l logx.Logger) grpc.UnaryServerInterceptor {
 			})
 		}
 
-		l.Debug("gRPC Message", fields...)
+		l.Info("gRPC Message", fields...)
 
 		return resp, err
 	}
@@ -81,7 +81,7 @@ func WithErrorLogs(l logx.Logger, options ...ErrorLogsOption) grpc.UnaryServerIn
 					{Key: "ctx_response_error_message", Value: err.Error()},
 				}
 				if inCodeList(errCode, logOptions.debugLevelCodes) {
-					l.Debug("gRPC Error", fields...)
+					l.Info("gRPC Error", fields...)
 				} else {
 					l.Error("gRPC Error", fields...)
 				}

--- a/grpcx/server_test.go
+++ b/grpcx/server_test.go
@@ -79,7 +79,7 @@ func TestWithRequestResponseLogs(t *testing.T) {
 
 		a.NoError(err)
 		a.Equal(expectedResponse, resp)
-		a.Contains(w.String(), fmt.Sprintf(`DEBU gRPC Message FIELDS ctx_full_method=%s ctx_request_content={"UserID":"%s"} ctx_response_content={"Result":"%s"}`, method, userID, okResult))
+		a.Contains(w.String(), fmt.Sprintf(`INFO gRPC Message FIELDS ctx_full_method=%s ctx_request_content={"UserID":"%s"} ctx_response_content={"Result":"%s"}`, method, userID, okResult))
 	})
 
 	t.Run("logs the response error", func(t *testing.T) {
@@ -101,7 +101,7 @@ func TestWithRequestResponseLogs(t *testing.T) {
 
 		a.Error(err)
 		a.Equal(expectedResponse, resp)
-		a.Contains(w.String(), fmt.Sprintf(`DEBU gRPC Message FIELDS ctx_full_method=%s ctx_request_content={"UserID":"%s"} ctx_response_content={"Result":"%s"} ctx_response_error=%s`, method, userID, okResult, expectedErr.Error()))
+		a.Contains(w.String(), fmt.Sprintf(`INFO gRPC Message FIELDS ctx_full_method=%s ctx_request_content={"UserID":"%s"} ctx_response_content={"Result":"%s"} ctx_response_error=%s`, method, userID, okResult, expectedErr.Error()))
 	})
 }
 
@@ -195,7 +195,7 @@ func TestWithErrorLogs(t *testing.T) {
 
 		a.Error(err)
 		a.Equal(expectedResponse, resp)
-		a.Contains(w.String(), fmt.Sprintf(`DEBU gRPC Error FIELDS ctx_full_method=%s ctx_request_content={"UserID":"%s"} ctx_response_content={"Result":"%s"} ctx_response_error_code=%s ctx_response_error_message=%s`, method, userID, okResult, expectedCode, expectedErr.Error()))
+		a.Contains(w.String(), fmt.Sprintf(`INFO gRPC Error FIELDS ctx_full_method=%s ctx_request_content={"UserID":"%s"} ctx_response_content={"Result":"%s"} ctx_response_error_code=%s ctx_response_error_message=%s`, method, userID, okResult, expectedCode, expectedErr.Error()))
 	})
 
 	t.Run("do not log error if discarded options added", func(t *testing.T) {

--- a/grpcx/server_test.go
+++ b/grpcx/server_test.go
@@ -79,7 +79,7 @@ func TestWithRequestResponseLogs(t *testing.T) {
 
 		a.NoError(err)
 		a.Equal(expectedResponse, resp)
-		a.Contains(w.String(), fmt.Sprintf(`INFO gRPC Message FIELDS ctx_full_method=%s ctx_request_content={"UserID":"%s"} ctx_response_content={"Result":"%s"}`, method, userID, okResult))
+		a.Contains(w.String(), fmt.Sprintf(`DEBU gRPC Message FIELDS ctx_full_method=%s ctx_request_content={"UserID":"%s"} ctx_response_content={"Result":"%s"}`, method, userID, okResult))
 	})
 
 	t.Run("logs the response error", func(t *testing.T) {
@@ -101,7 +101,7 @@ func TestWithRequestResponseLogs(t *testing.T) {
 
 		a.Error(err)
 		a.Equal(expectedResponse, resp)
-		a.Contains(w.String(), fmt.Sprintf(`INFO gRPC Message FIELDS ctx_full_method=%s ctx_request_content={"UserID":"%s"} ctx_response_content={"Result":"%s"} ctx_response_error=%s`, method, userID, okResult, expectedErr.Error()))
+		a.Contains(w.String(), fmt.Sprintf(`DEBU gRPC Message FIELDS ctx_full_method=%s ctx_request_content={"UserID":"%s"} ctx_response_content={"Result":"%s"} ctx_response_error=%s`, method, userID, okResult, expectedErr.Error()))
 	})
 }
 
@@ -172,7 +172,7 @@ func TestWithErrorLogs(t *testing.T) {
 
 		a.Error(err)
 		a.Equal(expectedResponse, resp)
-		a.Contains(w.String(), fmt.Sprintf(`INFO gRPC Error FIELDS ctx_full_method=%s ctx_request_content={"UserID":"%s"} ctx_response_content={"Result":"%s"} ctx_response_error_code=%s ctx_response_error_message=%s`, method, userID, okResult, expectedCode, expectedErr.Error()))
+		a.Contains(w.String(), fmt.Sprintf(`ERRO gRPC Error FIELDS ctx_full_method=%s ctx_request_content={"UserID":"%s"} ctx_response_content={"Result":"%s"} ctx_response_error_code=%s ctx_response_error_message=%s`, method, userID, okResult, expectedCode, expectedErr.Error()))
 	})
 
 	t.Run("logs error on debug level if custom options added", func(t *testing.T) {

--- a/logx/README.md
+++ b/logx/README.md
@@ -6,10 +6,6 @@ Features:
 
 -  pluggable io.Writer with the `WithWriter` decorator, default is os.Stdout
 -  2 marshallers available, a logstash one and a human-readable one
--  support debug and info levels, and a `WithLevel` decorator to change the level
+-  support debug and ~~info~~ error levels, and a `WithLevel` decorator to change the level
 -  support structured fields, for now keys are strings and values can be string (`logx.S`) and interger (`logx.I`)
 -  provides a Dummy logger for testing purposes
-
-Things not implemented yet:
-
-- colors

--- a/logx/README.md
+++ b/logx/README.md
@@ -6,6 +6,6 @@ Features:
 
 -  pluggable io.Writer with the `WithWriter` decorator, default is os.Stdout
 -  2 marshallers available, a logstash one and a human-readable one
--  support debug and ~~info~~ error levels, and a `WithLevel` decorator to change the level
--  support structured fields, for now keys are strings and values can be string (`logx.S`) and interger (`logx.I`)
+-  support ~~debug~~ info and error levels, and a `WithLevel` decorator to change the level
+-  support structured fields
 -  provides a Dummy logger for testing purposes

--- a/logx/logx.go
+++ b/logx/logx.go
@@ -27,7 +27,9 @@ func F(key string, value interface{}) Field {
 // Logging levels
 const (
 	DebugLevel Level = iota + 1
+	// Deprecated: use ErrorLevel instead
 	InfoLevel
+	ErrorLevel
 )
 
 // Level type
@@ -35,10 +37,12 @@ type Level uint8
 
 func (l Level) String() string {
 	switch l {
-	case 1:
+	case DebugLevel:
 		return "DEBU"
-	case 2:
+	case InfoLevel:
 		return "INFO"
+	case ErrorLevel:
+		return "ERRO"
 	default:
 		return "????"
 	}
@@ -59,10 +63,12 @@ type entry struct {
 	file    string
 }
 
-// Logger defines the log methods Debug and Info
+// Logger defines the log methods Debug and Error
 type Logger interface {
 	Debug(string, ...Field)
+	// Deprecated: use Error instead
 	Info(string, ...Field)
+	Error(string, ...Field)
 }
 
 // A Log implements Logger and has a marshaler, a writer and a minimum log level.
@@ -83,17 +89,25 @@ func (l *Log) Debug(message string, fields ...Field) {
 }
 
 // Info logs a message at level Info
+// Deprecated: use Error instead
 func (l *Log) Info(message string, fields ...Field) {
 	if InfoLevel >= l.level {
 		l.log(InfoLevel, message, fields...)
 	}
 }
 
+// Error logs a message at level Error
+func (l *Log) Error(message string, fields ...Field) {
+	if ErrorLevel >= l.level {
+		l.log(ErrorLevel, message, fields...)
+	}
+}
+
 func (l *Log) log(level Level, message string, fields ...Field) {
 	var t *time.Time
 	if !l.withoutTime {
-		time := time.Now()
-		t = &time
+		now := time.Now()
+		t = &now
 	}
 
 	var fi string

--- a/logx/logx.go
+++ b/logx/logx.go
@@ -26,8 +26,8 @@ func F(key string, value interface{}) Field {
 
 // Logging levels
 const (
+	// Deprecated: use InfoLevel instead
 	DebugLevel Level = iota + 1
-	// Deprecated: use ErrorLevel instead
 	InfoLevel
 	ErrorLevel
 )
@@ -49,7 +49,7 @@ func (l Level) String() string {
 }
 
 // DefaultMinLevel is the minimum debug level for which the logs will appear.
-var DefaultMinLevel = DebugLevel
+var DefaultMinLevel = InfoLevel
 
 // defaultFileSkipLevel is the number of stack frames to ascend to get the calling file
 var defaultFileSkipLevel = 3
@@ -63,10 +63,10 @@ type entry struct {
 	file    string
 }
 
-// Logger defines the log methods Debug and Error
+// Logger defines the log methods Info and Error
 type Logger interface {
+	// Deprecated: use Info instead
 	Debug(string, ...Field)
-	// Deprecated: use Error instead
 	Info(string, ...Field)
 	Error(string, ...Field)
 }
@@ -82,6 +82,7 @@ type Log struct {
 }
 
 // Debug logs a message at level Debug
+// Deprecated: use Info instead
 func (l *Log) Debug(message string, fields ...Field) {
 	if DebugLevel >= l.level {
 		l.log(DebugLevel, message, fields...)
@@ -89,7 +90,6 @@ func (l *Log) Debug(message string, fields ...Field) {
 }
 
 // Info logs a message at level Info
-// Deprecated: use Error instead
 func (l *Log) Info(message string, fields ...Field) {
 	if InfoLevel >= l.level {
 		l.log(InfoLevel, message, fields...)

--- a/logx/logx_test.go
+++ b/logx/logx_test.go
@@ -31,30 +31,30 @@ func TestDefaultAndLogstashLogging(t *testing.T) {
 		fields  []logx.Field
 		output  string
 	}{
-		{logger: defaultLogger, output: "DEBU  File: logx_test.go:57\n"},
-		{logger: defaultLogger, message: "Test", output: "DEBU Test File: logx_test.go:57\n"},
-		{logger: defaultLoggerWithoutFileInfo, message: "Test 2", fields: []logx.Field{logx.F("foo", "some stuff")}, output: "DEBU Test 2 FIELDS foo=some stuff\n"},
+		{logger: defaultLogger, output: "INFO  File: logx_test.go:57\n"},
+		{logger: defaultLogger, message: "Test", output: "INFO Test File: logx_test.go:57\n"},
+		{logger: defaultLoggerWithoutFileInfo, message: "Test 2", fields: []logx.Field{logx.F("foo", "some stuff")}, output: "INFO Test 2 FIELDS foo=some stuff\n"},
 		// "type" is a logstash reserved keyword but just changes in logstash log
-		{logger: defaultLogger, message: "Test 3", fields: []logx.Field{logx.F("type", "val")}, output: "DEBU Test 3 FIELDS type=val File: logx_test.go:55\n"},
-		{logger: defaultLogger, message: "Test 4", fields: []logx.Field{logx.F("number", 111)}, output: "DEBU Test 4 FIELDS number=111 File: logx_test.go:55\n"},
-		{logger: defaultLoggerWithoutFileInfo, message: "Test 5", fields: []logx.Field{logx.F("type", "val"), logx.F("myint", 111), logx.F("myfloat", 3.1416)}, output: "DEBU Test 5 FIELDS type=val myint=111 myfloat=3.1416\n"},
+		{logger: defaultLogger, message: "Test 3", fields: []logx.Field{logx.F("type", "val")}, output: "INFO Test 3 FIELDS type=val File: logx_test.go:55\n"},
+		{logger: defaultLogger, message: "Test 4", fields: []logx.Field{logx.F("number", 111)}, output: "INFO Test 4 FIELDS number=111 File: logx_test.go:55\n"},
+		{logger: defaultLoggerWithoutFileInfo, message: "Test 5", fields: []logx.Field{logx.F("type", "val"), logx.F("myint", 111), logx.F("myfloat", 3.1416)}, output: "INFO Test 5 FIELDS type=val myint=111 myfloat=3.1416\n"},
 
-		{logger: logstashLogger, output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:57\",\"message\":\"\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
-		{logger: logstashLogger, message: "Test", output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:57\",\"message\":\"Test\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
-		{logger: logstashLoggerWithoutFileInfo, message: "Test 2", fields: []logx.Field{logx.F("foo", "some stuff")}, output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"foo\":\"some stuff\",\"message\":\"Test 2\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
+		{logger: logstashLogger, output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:57\",\"message\":\"\",\"product\":\"myprod\",\"severity\":\"INFO\"}\n", hostname)},
+		{logger: logstashLogger, message: "Test", output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:57\",\"message\":\"Test\",\"product\":\"myprod\",\"severity\":\"INFO\"}\n", hostname)},
+		{logger: logstashLoggerWithoutFileInfo, message: "Test 2", fields: []logx.Field{logx.F("foo", "some stuff")}, output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"foo\":\"some stuff\",\"message\":\"Test 2\",\"product\":\"myprod\",\"severity\":\"INFO\"}\n", hostname)},
 		// "type" is a logstash reserved keyword but just changes in logstash log
-		{logger: logstashLogger, message: "Test 3", fields: []logx.Field{logx.F("type", "val")}, output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:55\",\"message\":\"Test 3\",\"product\":\"myprod\",\"severity\":\"DEBU\",\"typex\":\"val\"}\n", hostname)},
-		{logger: logstashLogger, message: "Test 4", fields: []logx.Field{logx.F("number", 111)}, output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:55\",\"message\":\"Test 4\",\"number\":\"111\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
-		{logger: logstashLoggerWithoutFileInfo, message: "Test 5", fields: []logx.Field{logx.F("type", "val"), logx.F("number", 111)}, output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"message\":\"Test 5\",\"number\":\"111\",\"product\":\"myprod\",\"severity\":\"DEBU\",\"typex\":\"val\"}\n", hostname)},
+		{logger: logstashLogger, message: "Test 3", fields: []logx.Field{logx.F("type", "val")}, output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:55\",\"message\":\"Test 3\",\"product\":\"myprod\",\"severity\":\"INFO\",\"typex\":\"val\"}\n", hostname)},
+		{logger: logstashLogger, message: "Test 4", fields: []logx.Field{logx.F("number", 111)}, output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:55\",\"message\":\"Test 4\",\"number\":\"111\",\"product\":\"myprod\",\"severity\":\"INFO\"}\n", hostname)},
+		{logger: logstashLoggerWithoutFileInfo, message: "Test 5", fields: []logx.Field{logx.F("type", "val"), logx.F("number", 111)}, output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"message\":\"Test 5\",\"number\":\"111\",\"product\":\"myprod\",\"severity\":\"INFO\",\"typex\":\"val\"}\n", hostname)},
 
-		{logger: logstashLoggerWithOriginalValues, message: "Test With Original Values But No Fields", output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:57\",\"message\":\"Test With Original Values But No Fields\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
-		{logger: logstashLoggerWithOriginalValues, message: "Test With Original Values", fields: []logx.Field{logx.F("string", "hi there"), logx.F("number", 123), logx.F("array", []int{1, 2, 3}), logx.F("map", map[string]int{"foo": 123, "bar": 456})}, output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"array\":[1,2,3],\"channel\":\"mychan\",\"file\":\"logx_test.go:55\",\"map\":{\"bar\":456,\"foo\":123},\"message\":\"Test With Original Values\",\"number\":123,\"product\":\"myprod\",\"severity\":\"DEBU\",\"string\":\"hi there\"}\n", hostname)},
-		{logger: logstashLoggerWithEnvironment, message: "Test", output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"environment\":\"prod\",\"file\":\"logx_test.go:57\",\"message\":\"Test\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
+		{logger: logstashLoggerWithOriginalValues, message: "Test With Original Values But No Fields", output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:57\",\"message\":\"Test With Original Values But No Fields\",\"product\":\"myprod\",\"severity\":\"INFO\"}\n", hostname)},
+		{logger: logstashLoggerWithOriginalValues, message: "Test With Original Values", fields: []logx.Field{logx.F("string", "hi there"), logx.F("number", 123), logx.F("array", []int{1, 2, 3}), logx.F("map", map[string]int{"foo": 123, "bar": 456})}, output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"array\":[1,2,3],\"channel\":\"mychan\",\"file\":\"logx_test.go:55\",\"map\":{\"bar\":456,\"foo\":123},\"message\":\"Test With Original Values\",\"number\":123,\"product\":\"myprod\",\"severity\":\"INFO\",\"string\":\"hi there\"}\n", hostname)},
+		{logger: logstashLoggerWithEnvironment, message: "Test", output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"environment\":\"prod\",\"file\":\"logx_test.go:57\",\"message\":\"Test\",\"product\":\"myprod\",\"severity\":\"INFO\"}\n", hostname)},
 	} {
 		if tc.fields != nil {
-			tc.logger.Debug(tc.message, tc.fields...)
+			tc.logger.Info(tc.message, tc.fields...)
 		} else {
-			tc.logger.Debug(tc.message)
+			tc.logger.Info(tc.message)
 		}
 		a.Equal(tc.output, <-rec)
 	}
@@ -67,11 +67,11 @@ func TestLoggingWithCustomSkipLevel(t *testing.T) {
 	defaultLogger := logx.New(logx.WriterOpt(rec), logx.WithoutTimeOpt(), logx.AdditionalFileSkipLevel(1))
 
 	log(defaultLogger, "Test")
-	a.Equal("DEBU Test File: logx_test.go:69\n", <-rec)
+	a.Equal("INFO Test File: logx_test.go:69\n", <-rec)
 }
 
 func log(logger logx.Logger, message string) {
-	logger.Debug(message)
+	logger.Info(message)
 }
 
 func TestLogLevel(t *testing.T) {
@@ -81,7 +81,7 @@ func TestLogLevel(t *testing.T) {
 	var buf bytes.Buffer
 	logger := logx.New(logx.WriterOpt(&buf))
 
-	logger.Debug("test")
+	logger.Info("test")
 	content, err := ioutil.ReadAll(&buf)
 	a.NoError(err)
 	a.True(len(content) > 0)
@@ -94,7 +94,7 @@ func TestLogLevel(t *testing.T) {
 	logger = logx.New(logx.WriterOpt(&buf), logx.LevelOpt(logx.ErrorLevel))
 
 	// since now the min level is error then a debug message won't be logged
-	logger.Debug("test")
+	logger.Info("test")
 	content, err = ioutil.ReadAll(&buf)
 	a.NoError(err)
 	a.Len(content, 0)
@@ -112,7 +112,7 @@ func TestDummy(t *testing.T) {
 	var buf bytes.Buffer
 	logger := logx.NewDummy(logx.WriterOpt(&buf))
 
-	logger.Debug("test")
+	logger.Info("test")
 	content, err := ioutil.ReadAll(&buf)
 	a.NoError(err)
 	a.Len(content, 0)

--- a/logx/logx_test.go
+++ b/logx/logx_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func TestDefaultAndLogstashLogging(t *testing.T) {
-	assert := assert.New(t)
+	t.Parallel()
+	a := assert.New(t)
 
 	rec := make(recorder, 1)
 	defaultLogger := logx.New(logx.WriterOpt(rec), logx.WithoutTimeOpt())
@@ -30,42 +31,43 @@ func TestDefaultAndLogstashLogging(t *testing.T) {
 		fields  []logx.Field
 		output  string
 	}{
-		{defaultLogger, "", nil, "DEBU  File: logx_test.go:56\n"},
-		{defaultLogger, "Test", nil, "DEBU Test File: logx_test.go:56\n"},
-		{defaultLoggerWithoutFileInfo, "Test 2", []logx.Field{logx.F("foo", "some stuff")}, "DEBU Test 2 FIELDS foo=some stuff\n"},
+		{logger: defaultLogger, output: "DEBU  File: logx_test.go:57\n"},
+		{logger: defaultLogger, message: "Test", output: "DEBU Test File: logx_test.go:57\n"},
+		{logger: defaultLoggerWithoutFileInfo, message: "Test 2", fields: []logx.Field{logx.F("foo", "some stuff")}, output: "DEBU Test 2 FIELDS foo=some stuff\n"},
 		// "type" is a logstash reserved keyword but just changes in logstash log
-		{defaultLogger, "Test 3", []logx.Field{logx.F("type", "val")}, "DEBU Test 3 FIELDS type=val File: logx_test.go:54\n"},
-		{defaultLogger, "Test 4", []logx.Field{logx.F("number", 111)}, "DEBU Test 4 FIELDS number=111 File: logx_test.go:54\n"},
-		{defaultLoggerWithoutFileInfo, "Test 5", []logx.Field{logx.F("type", "val"), logx.F("myint", 111), logx.F("myfloat", 3.1416)}, "DEBU Test 5 FIELDS type=val myint=111 myfloat=3.1416\n"},
+		{logger: defaultLogger, message: "Test 3", fields: []logx.Field{logx.F("type", "val")}, output: "DEBU Test 3 FIELDS type=val File: logx_test.go:55\n"},
+		{logger: defaultLogger, message: "Test 4", fields: []logx.Field{logx.F("number", 111)}, output: "DEBU Test 4 FIELDS number=111 File: logx_test.go:55\n"},
+		{logger: defaultLoggerWithoutFileInfo, message: "Test 5", fields: []logx.Field{logx.F("type", "val"), logx.F("myint", 111), logx.F("myfloat", 3.1416)}, output: "DEBU Test 5 FIELDS type=val myint=111 myfloat=3.1416\n"},
 
-		{logstashLogger, "", nil, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:56\",\"message\":\"\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
-		{logstashLogger, "Test", nil, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:56\",\"message\":\"Test\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
-		{logstashLoggerWithoutFileInfo, "Test 2", []logx.Field{logx.F("foo", "some stuff")}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"foo\":\"some stuff\",\"message\":\"Test 2\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
+		{logger: logstashLogger, output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:57\",\"message\":\"\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
+		{logger: logstashLogger, message: "Test", output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:57\",\"message\":\"Test\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
+		{logger: logstashLoggerWithoutFileInfo, message: "Test 2", fields: []logx.Field{logx.F("foo", "some stuff")}, output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"foo\":\"some stuff\",\"message\":\"Test 2\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
 		// "type" is a logstash reserved keyword but just changes in logstash log
-		{logstashLogger, "Test 3", []logx.Field{logx.F("type", "val")}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:54\",\"message\":\"Test 3\",\"product\":\"myprod\",\"severity\":\"DEBU\",\"typex\":\"val\"}\n", hostname)},
-		{logstashLogger, "Test 4", []logx.Field{logx.F("number", 111)}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:54\",\"message\":\"Test 4\",\"number\":\"111\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
-		{logstashLoggerWithoutFileInfo, "Test 5", []logx.Field{logx.F("type", "val"), logx.F("number", 111)}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"message\":\"Test 5\",\"number\":\"111\",\"product\":\"myprod\",\"severity\":\"DEBU\",\"typex\":\"val\"}\n", hostname)},
+		{logger: logstashLogger, message: "Test 3", fields: []logx.Field{logx.F("type", "val")}, output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:55\",\"message\":\"Test 3\",\"product\":\"myprod\",\"severity\":\"DEBU\",\"typex\":\"val\"}\n", hostname)},
+		{logger: logstashLogger, message: "Test 4", fields: []logx.Field{logx.F("number", 111)}, output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:55\",\"message\":\"Test 4\",\"number\":\"111\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
+		{logger: logstashLoggerWithoutFileInfo, message: "Test 5", fields: []logx.Field{logx.F("type", "val"), logx.F("number", 111)}, output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"message\":\"Test 5\",\"number\":\"111\",\"product\":\"myprod\",\"severity\":\"DEBU\",\"typex\":\"val\"}\n", hostname)},
 
-		{logstashLoggerWithOriginalValues, "Test With Original Values But No Fields", nil, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:56\",\"message\":\"Test With Original Values But No Fields\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
-		{logstashLoggerWithOriginalValues, "Test With Original Values", []logx.Field{logx.F("string", "hi there"), logx.F("number", 123), logx.F("array", []int{1, 2, 3}), logx.F("map", map[string]int{"foo": 123, "bar": 456})}, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"array\":[1,2,3],\"channel\":\"mychan\",\"file\":\"logx_test.go:54\",\"map\":{\"bar\":456,\"foo\":123},\"message\":\"Test With Original Values\",\"number\":123,\"product\":\"myprod\",\"severity\":\"DEBU\",\"string\":\"hi there\"}\n", hostname)},
-		{logstashLoggerWithEnvironment, "Test", nil, fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"environment\":\"prod\",\"file\":\"logx_test.go:56\",\"message\":\"Test\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
+		{logger: logstashLoggerWithOriginalValues, message: "Test With Original Values But No Fields", output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"file\":\"logx_test.go:57\",\"message\":\"Test With Original Values But No Fields\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
+		{logger: logstashLoggerWithOriginalValues, message: "Test With Original Values", fields: []logx.Field{logx.F("string", "hi there"), logx.F("number", 123), logx.F("array", []int{1, 2, 3}), logx.F("map", map[string]int{"foo": 123, "bar": 456})}, output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"array\":[1,2,3],\"channel\":\"mychan\",\"file\":\"logx_test.go:55\",\"map\":{\"bar\":456,\"foo\":123},\"message\":\"Test With Original Values\",\"number\":123,\"product\":\"myprod\",\"severity\":\"DEBU\",\"string\":\"hi there\"}\n", hostname)},
+		{logger: logstashLoggerWithEnvironment, message: "Test", output: fmt.Sprintf("{\"@version\":1,\"app_server_name\":\"%s\",\"application\":\"myapp\",\"channel\":\"mychan\",\"environment\":\"prod\",\"file\":\"logx_test.go:57\",\"message\":\"Test\",\"product\":\"myprod\",\"severity\":\"DEBU\"}\n", hostname)},
 	} {
 		if tc.fields != nil {
 			tc.logger.Debug(tc.message, tc.fields...)
 		} else {
 			tc.logger.Debug(tc.message)
 		}
-		assert.Equal(tc.output, <-rec)
+		a.Equal(tc.output, <-rec)
 	}
 }
 
 func TestLoggingWithCustomSkipLevel(t *testing.T) {
-	assert := assert.New(t)
+	t.Parallel()
+	a := assert.New(t)
 	rec := make(recorder, 1)
 	defaultLogger := logx.New(logx.WriterOpt(rec), logx.WithoutTimeOpt(), logx.AdditionalFileSkipLevel(1))
 
 	log(defaultLogger, "Test")
-	assert.Equal("DEBU Test File: logx_test.go:67\n", <-rec)
+	a.Equal("DEBU Test File: logx_test.go:69\n", <-rec)
 }
 
 func log(logger logx.Logger, message string) {
@@ -73,50 +75,52 @@ func log(logger logx.Logger, message string) {
 }
 
 func TestLogLevel(t *testing.T) {
-	assert := assert.New(t)
+	t.Parallel()
+	a := assert.New(t)
 
 	var buf bytes.Buffer
 	logger := logx.New(logx.WriterOpt(&buf))
 
 	logger.Debug("test")
 	content, err := ioutil.ReadAll(&buf)
-	assert.NoError(err)
-	assert.True(len(content) > 0)
+	a.NoError(err)
+	a.True(len(content) > 0)
 
-	logger.Info("test2")
+	logger.Error("test2")
 	content, err = ioutil.ReadAll(&buf)
-	assert.NoError(err)
-	assert.True(len(content) > 0)
+	a.NoError(err)
+	a.True(len(content) > 0)
 
-	logger = logx.New(logx.WriterOpt(&buf), logx.LevelOpt(logx.InfoLevel))
+	logger = logx.New(logx.WriterOpt(&buf), logx.LevelOpt(logx.ErrorLevel))
 
-	// since now the min level is info then a debug message won't be logged
+	// since now the min level is error then a debug message won't be logged
 	logger.Debug("test")
 	content, err = ioutil.ReadAll(&buf)
-	assert.NoError(err)
-	assert.Len(content, 0)
+	a.NoError(err)
+	a.Len(content, 0)
 
-	logger.Info("test2")
+	logger.Error("test2")
 	content, err = ioutil.ReadAll(&buf)
-	assert.NoError(err)
-	assert.True(len(content) > 0)
+	a.NoError(err)
+	a.True(len(content) > 0)
 }
 
 func TestDummy(t *testing.T) {
-	assert := assert.New(t)
+	t.Parallel()
+	a := assert.New(t)
 
 	var buf bytes.Buffer
 	logger := logx.NewDummy(logx.WriterOpt(&buf))
 
 	logger.Debug("test")
 	content, err := ioutil.ReadAll(&buf)
-	assert.NoError(err)
-	assert.Len(content, 0)
+	a.NoError(err)
+	a.Len(content, 0)
 
-	logger.Info("test2")
+	logger.Error("test2")
 	content, err = ioutil.ReadAll(&buf)
-	assert.NoError(err)
-	assert.Len(content, 0)
+	a.NoError(err)
+	a.Len(content, 0)
 }
 
 type recorder chan string

--- a/recovery/recovery.go
+++ b/recovery/recovery.go
@@ -26,7 +26,7 @@ func Handler(l logx.Logger, opts ...Options) func() {
 
 	return func() {
 		if r := recover(); r != nil {
-			l.Info(fmt.Sprintf("%v", r), logx.F("stack_trace", strings.Split(string(debug.Stack()), "\n")))
+			l.Error(fmt.Sprintf("%v", r), logx.F("stack_trace", strings.Split(string(debug.Stack()), "\n")))
 			o.exitFunc()
 		}
 	}


### PR DESCRIPTION
The `Logger.Info` severity does not reflect happening under an error condition. That's why we're deprectating it in favor a new `Logger.Error` method. 