### PR TITLE
Metrics for Datadog with Unix Domain Sockets

### DIFF
--- a/metrics/factory.go
+++ b/metrics/factory.go
@@ -37,7 +37,7 @@ func NewMetricsRunnerFromDSN(dsn string) (Metrics, contextx.Runner) {
 			panic("datadog metrics need a namespace")
 		}
 		publisher = NewDataDogUnix(
-			WithDDAddress(params.Get("addr")),
+			WithDDUnixAddress(params.Get("addr")),
 		)
 	case "datadog-lambda":
 		if namespace == "" {

--- a/metrics/factory.go
+++ b/metrics/factory.go
@@ -32,6 +32,13 @@ func NewMetricsRunnerFromDSN(dsn string) (Metrics, contextx.Runner) {
 			WithDDHost(params.Get("host")),
 			WithDDPort(params.Get("port")),
 		)
+	case "datadog-unix":
+		if namespace == "" {
+			panic("datadog metrics need a namespace")
+		}
+		publisher = NewDataDogUnix(
+			WithDDAddress(params.Get("addr")),
+		)
 	case "datadog-lambda":
 		if namespace == "" {
 			panic("datadog metrics need a namespace")

--- a/metrics/publisher.go
+++ b/metrics/publisher.go
@@ -149,7 +149,7 @@ func NewDataDogUnix(opts ...DatadogOption) *Publisher {
 		options.flushInterval = datadogFlush
 	}
 
-	conn, err := net.Dial("unix", options.unixAddress)
+	conn, err := net.Dial("unixgram", options.unixAddress)
 	if err != nil {
 		panic(fmt.Sprintf("cannot create Unix client: `%s`", err.Error()))
 	}


### PR DESCRIPTION
New Datadog constructor func that allows to send metrics to the Datadog Agent via Unix Domain Sockets.

This is necessary to use [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes), as UDP is not supported.

More info: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/?tab=kubernetes