### PR TITLE
gRPC Daemon and Application

### DIFF
--- a/grpcx/deamon.go
+++ b/grpcx/deamon.go
@@ -3,6 +3,7 @@ package grpcx
 import (
 	"context"
 	"fmt"
+	"log"
 	"net"
 
 	"google.golang.org/grpc"
@@ -10,13 +11,27 @@ import (
 	"github.com/socialpoint-labs/bsk/contextx"
 )
 
-// Daemon represents a runnable gRPC daemon
+// Daemon represents a runnable gRPC daemon.
+//
+// A gRPC Daemon will manage the lifecycle of the given gRPC server, gracefully shutting it down
+// once the runner context is done.
+//
+// Either a port or a listener is needed for the daemon to run. If no listener is given,
+// a TCP listener will be created for the given port.
+//
+// Typically, you'll want to pass one or more Applications. The daemon will register the gRPC
+// endpoints of every application and run it with the runner context.
+// A daemon can run without any Applications. This can be interesting for certain use cases where you want
+// to manage the server by yourself and delegate the lifecycle management.
+//
+// Errors that might happen during the listener setup and running the gRPC server will be passed
+// through an optional error func. If none is given, they'll be printed to the standard output.
 type Daemon struct {
+	svr  *grpc.Server
 	port int
 	lis  net.Listener
-	svr  *grpc.Server
-	ef   func(error)
 	apps []Application
+	ef   func(error)
 }
 
 // Application is a contextx.Runner that can register gRPC services
@@ -25,26 +40,54 @@ type Application interface {
 	RegisterGRPC(grpc.ServiceRegistrar)
 }
 
-// NewDaemonWithPort creates a gRPC Daemon listening at the given port.
-func NewDaemonWithPort(port int, svr *grpc.Server, ef func(error), apps ...Application) Daemon {
-	return Daemon{
-		port: port,
-		svr:  svr,
-		ef:   ef,
-		apps: apps,
+type DaemonOption func(*daemonOptions)
+
+type daemonOptions struct {
+	port int
+	lis  net.Listener
+	apps []Application
+	ef   func(error)
+}
+
+func WithPort(p int) DaemonOption {
+	return func(opts *daemonOptions) {
+		opts.port = p
+	}
+}
+
+func WithListener(lis net.Listener) DaemonOption {
+	return func(opts *daemonOptions) {
+		opts.lis = lis
+	}
+}
+
+func WithApplications(apps ...Application) DaemonOption {
+	return func(opts *daemonOptions) {
+		opts.apps = apps
+	}
+}
+
+func WithErrorFunc(ef func(error)) DaemonOption {
+	return func(opts *daemonOptions) {
+		opts.ef = ef
 	}
 }
 
 // NewDaemon creates a gRPC Daemon for the given listener.
-//
-// The lifecycle of the listener will *not* be managed by this function, nor by the Daemon. The application
-// needs to take manage it.
-func NewDaemon(lis net.Listener, svr *grpc.Server, ef func(error), apps ...Application) Daemon {
+func NewDaemon(svr *grpc.Server, opts ...DaemonOption) Daemon {
+	options := &daemonOptions{
+		ef: defaultErrorFunc,
+	}
+	for _, opt := range opts {
+		opt(options)
+	}
+
 	return Daemon{
-		lis:  lis,
 		svr:  svr,
-		ef:   ef,
-		apps: apps,
+		port: options.port,
+		lis:  options.lis,
+		apps: options.apps,
+		ef:   options.ef,
 	}
 }
 
@@ -81,4 +124,8 @@ func (d Daemon) listener() (net.Listener, error) {
 	}
 
 	return net.Listen("tcp", fmt.Sprintf(":%d", d.port))
+}
+
+func defaultErrorFunc(err error) {
+	log.Println(err.Error())
 }

--- a/grpcx/deamon.go
+++ b/grpcx/deamon.go
@@ -13,7 +13,9 @@ import (
 // Daemon represents a runnable gRPC daemon
 type Daemon struct {
 	port int
+	lis  net.Listener
 	svr  *grpc.Server
+	ef   func(error)
 	apps []Application
 }
 
@@ -23,16 +25,31 @@ type Application interface {
 	RegisterGRPC(grpc.ServiceRegistrar)
 }
 
-func NewDaemon(port int, svr *grpc.Server, apps ...Application) Daemon {
+// NewDaemonWithPort creates a gRPC Daemon listening at the given port.
+func NewDaemonWithPort(port int, svr *grpc.Server, ef func(error), apps ...Application) Daemon {
 	return Daemon{
 		port: port,
 		svr:  svr,
+		ef:   ef,
 		apps: apps,
 	}
 }
 
-// Run registers and runs every application of the Daemon with a gRPC server,
-// then starts it and gracefully shuts it down once the context is done.
+// NewDaemon creates a gRPC Daemon for the given listener.
+//
+// The lifecycle of the listener will *not* be managed by this function, nor by the Daemon. The application
+// needs to take manage it.
+func NewDaemon(lis net.Listener, svr *grpc.Server, ef func(error), apps ...Application) Daemon {
+	return Daemon{
+		lis:  lis,
+		svr:  svr,
+		ef:   ef,
+		apps: apps,
+	}
+}
+
+// Run registers every application of the Daemon with a gRPC server and runs them,
+// then starts the server and gracefully shuts it down once the context is done.
 func (d Daemon) Run(ctx context.Context) {
 	for _, app := range d.apps {
 		app.RegisterGRPC(d.svr)
@@ -40,18 +57,28 @@ func (d Daemon) Run(ctx context.Context) {
 		go app.Run(ctx)
 	}
 
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", d.port))
+	listener, err := d.listener()
 	if err != nil {
-		panic(err.Error())
+		d.ef(err)
+		return
 	}
 
 	defer d.svr.GracefulStop()
 
 	go func() {
 		if err := d.svr.Serve(listener); err != nil {
-			panic(err.Error())
+			d.ef(err)
+			return
 		}
 	}()
 
 	<-ctx.Done()
+}
+
+func (d Daemon) listener() (net.Listener, error) {
+	if d.lis != nil {
+		return d.lis, nil
+	}
+
+	return net.Listen("tcp", fmt.Sprintf(":%d", d.port))
 }

--- a/grpcx/deamon.go
+++ b/grpcx/deamon.go
@@ -20,7 +20,7 @@ type Daemon struct {
 // Application is a contextx.Runner that can register gRPC services
 type Application interface {
 	contextx.Runner
-	RegisterGRPC(*grpc.Server)
+	RegisterGRPC(grpc.ServiceRegistrar)
 }
 
 func NewDaemon(port int, svr *grpc.Server, apps ...Application) Daemon {

--- a/grpcx/deamon.go
+++ b/grpcx/deamon.go
@@ -1,0 +1,57 @@
+package grpcx
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"google.golang.org/grpc"
+
+	"github.com/socialpoint-labs/bsk/contextx"
+)
+
+// Daemon represents a runnable gRPC daemon
+type Daemon struct {
+	port int
+	svr  *grpc.Server
+	apps []Application
+}
+
+// Application is a contextx.Runner that can register gRPC services
+type Application interface {
+	contextx.Runner
+	RegisterGRPC(*grpc.Server)
+}
+
+func NewDaemon(port int, svr *grpc.Server, apps ...Application) Daemon {
+	return Daemon{
+		port: port,
+		svr:  svr,
+		apps: apps,
+	}
+}
+
+// Run registers and runs every application of the Daemon with a gRPC server,
+// then starts it and gracefully shuts it down once the context is done.
+func (d Daemon) Run(ctx context.Context) {
+	for _, app := range d.apps {
+		app.RegisterGRPC(d.svr)
+
+		go app.Run(ctx)
+	}
+
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", d.port))
+	if err != nil {
+		panic(err.Error())
+	}
+
+	defer d.svr.GracefulStop()
+
+	go func() {
+		if err := d.svr.Serve(listener); err != nil {
+			panic(err.Error())
+		}
+	}()
+
+	<-ctx.Done()
+}

--- a/grpcx/deamon.go
+++ b/grpcx/deamon.go
@@ -2,7 +2,6 @@ package grpcx
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net"
 
@@ -16,19 +15,15 @@ import (
 // A gRPC Daemon will manage the lifecycle of the given gRPC server, gracefully shutting it down
 // once the runner context is done.
 //
-// Either a port or a listener is needed for the daemon to run. If no listener is given,
-// a TCP listener will be created for the given port.
-//
-// Typically, you'll want to pass one or more Applications. The daemon will register the gRPC
+// Typically, you'll want to pass one or more Applications as options. The daemon will register the gRPC
 // endpoints of every application and run it with the runner context.
 // A daemon can run without any Applications. This can be interesting for certain use cases where you want
 // to manage the server by yourself and delegate the lifecycle management.
 //
-// Errors that might happen during the listener setup and running the gRPC server will be passed
-// through an optional error func. If none is given, they'll be printed to the standard output.
+// Errors that might happen  running the gRPC server will be passed through an optional error func.
+// If none is given, they'll be printed to the standard output.
 type Daemon struct {
 	svr  *grpc.Server
-	port int
 	lis  net.Listener
 	apps []Application
 	ef   func(error)
@@ -43,22 +38,8 @@ type Application interface {
 type DaemonOption func(*daemonOptions)
 
 type daemonOptions struct {
-	port int
-	lis  net.Listener
 	apps []Application
 	ef   func(error)
-}
-
-func WithPort(p int) DaemonOption {
-	return func(opts *daemonOptions) {
-		opts.port = p
-	}
-}
-
-func WithListener(lis net.Listener) DaemonOption {
-	return func(opts *daemonOptions) {
-		opts.lis = lis
-	}
 }
 
 func WithApplications(apps ...Application) DaemonOption {
@@ -73,8 +54,8 @@ func WithErrorFunc(ef func(error)) DaemonOption {
 	}
 }
 
-// NewDaemon creates a gRPC Daemon for the given listener.
-func NewDaemon(svr *grpc.Server, opts ...DaemonOption) Daemon {
+// NewDaemon creates a gRPC Daemon for the given gRPC server and listener.
+func NewDaemon(svr *grpc.Server, lis net.Listener, opts ...DaemonOption) Daemon {
 	options := &daemonOptions{
 		ef: defaultErrorFunc,
 	}
@@ -84,8 +65,7 @@ func NewDaemon(svr *grpc.Server, opts ...DaemonOption) Daemon {
 
 	return Daemon{
 		svr:  svr,
-		port: options.port,
-		lis:  options.lis,
+		lis:  lis,
 		apps: options.apps,
 		ef:   options.ef,
 	}
@@ -100,30 +80,16 @@ func (d Daemon) Run(ctx context.Context) {
 		go app.Run(ctx)
 	}
 
-	listener, err := d.listener()
-	if err != nil {
-		d.ef(err)
-		return
-	}
-
 	defer d.svr.GracefulStop()
 
 	go func() {
-		if err := d.svr.Serve(listener); err != nil {
+		if err := d.svr.Serve(d.lis); err != nil {
 			d.ef(err)
 			return
 		}
 	}()
 
 	<-ctx.Done()
-}
-
-func (d Daemon) listener() (net.Listener, error) {
-	if d.lis != nil {
-		return d.lis, nil
-	}
-
-	return net.Listen("tcp", fmt.Sprintf(":%d", d.port))
 }
 
 func defaultErrorFunc(err error) {

--- a/grpcx/deamon_test.go
+++ b/grpcx/deamon_test.go
@@ -1,0 +1,140 @@
+package grpcx_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/encoding"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/socialpoint-labs/bsk/grpcx"
+)
+
+func TestDaemon_Run_CancellingContext(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	callback := make(chan func())
+	server := testServer(callback)
+	lis := bufconn.Listen(1024 * 1024)
+	defer lis.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	dae := grpcx.NewDaemon(server, grpcx.WithListener(lis), grpcx.WithErrorFunc(func(err error) { t.Fatal(err) }))
+	go dae.Run(ctx)
+	cli := newTestClient(lis)
+
+	// regular call
+	cli.call()
+	callback <- func() {}
+	resp1 := <-cli.resp
+
+	// cancel context in the middle of a call
+	cli.call()
+	callback <- cancel
+	resp2 := <-cli.resp
+
+	// call after context is cancelled
+	cli.call()
+	err := <-cli.errs
+
+	a.Equal("call #1", resp1)
+	a.Equal("call #2", resp2)
+	a.EqualError(err, `rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing closed"`)
+}
+
+func TestDaemon_Run_WithInvalidPort(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	server := exampleServer()
+	chErr := make(chan error)
+	dae := grpcx.NewDaemon(server, grpcx.WithPort(-1), grpcx.WithErrorFunc(func(err error) {
+		chErr <- err
+	}))
+
+	go dae.Run(ctx)
+
+	a.EqualError(<-chErr, "listen tcp: address -1: invalid port")
+}
+
+func testServer(callback chan func()) *grpc.Server {
+	var calls int
+
+	encoding.RegisterCodec(noopCodec{})
+	return grpc.NewServer(grpc.UnknownServiceHandler(func(srv interface{}, stream grpc.ServerStream) error {
+		cb := <-callback
+		cb()
+
+		calls++
+		return stream.SendMsg([]byte(fmt.Sprintf("call #%d", calls)))
+	}))
+}
+
+type noopCodec struct{}
+
+func (noopCodec) Marshal(v interface{}) ([]byte, error) {
+	return v.([]byte), nil
+}
+
+func (noopCodec) Unmarshal(data []byte, v interface{}) error {
+	*(v.(*[]byte)) = data
+	return nil
+}
+
+func (noopCodec) Name() string {
+	return "noop-codec"
+}
+
+func (noopCodec) String() string {
+	return "noop-codec"
+}
+
+type testClient struct {
+	lis  *bufconn.Listener
+	resp chan string
+	errs chan error
+}
+
+func newTestClient(lis *bufconn.Listener) *testClient {
+	return &testClient{
+		lis:  lis,
+		resp: make(chan string),
+		errs: make(chan error),
+	}
+}
+
+func (c testClient) call() {
+	go c.callAsync()
+}
+
+func (c testClient) callAsync() {
+	ctx := context.Background()
+	cc, err := grpc.DialContext(
+		ctx, "",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return c.lis.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.CustomCodecCallOption{Codec: noopCodec{}}),
+	)
+	if err != nil {
+		c.errs <- err
+	}
+	defer cc.Close()
+
+	var out []byte
+	err = cc.Invoke(ctx, "/test.service/test.call", nil, &out)
+	if err != nil {
+		c.errs <- err
+	}
+
+	c.resp <- string(out)
+}

--- a/grpcx/example_daemon_test.go
+++ b/grpcx/example_daemon_test.go
@@ -20,14 +20,17 @@ func ExampleDaemon_Run() {
 	defer lis.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	dae := grpcx.NewDaemon(server, grpcx.WithListener(lis))
+	app := exampleApplication{}
+	dae := grpcx.NewDaemon(server, grpcx.WithListener(lis), grpcx.WithApplications(app))
 	go dae.Run(ctx)
 
 	exampleCall(ctx, lis)
 
 	cancel()
 
-	// Output: /test.service/test.call rpc handled!
+	// Output: example rpcs registered
+	// example application run
+	// /test.service/test.call rpc handled!
 	// got response from server: bye
 }
 
@@ -87,4 +90,15 @@ func (noopCodec) Name() string {
 
 func (noopCodec) String() string {
 	return "noop-codec"
+}
+
+type exampleApplication struct {
+}
+
+func (e exampleApplication) Run(ctx context.Context) {
+	fmt.Println("example application run")
+}
+
+func (e exampleApplication) RegisterGRPC(registrar grpc.ServiceRegistrar) {
+	fmt.Println("example rpcs registered")
 }

--- a/grpcx/example_daemon_test.go
+++ b/grpcx/example_daemon_test.go
@@ -1,0 +1,90 @@
+package grpcx_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/encoding"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/socialpoint-labs/bsk/grpcx"
+)
+
+func ExampleDaemon_Run() {
+	server := exampleServer()
+	lis := bufconn.Listen(1024 * 1024)
+	defer lis.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	dae := grpcx.NewDaemon(server, grpcx.WithListener(lis))
+	go dae.Run(ctx)
+
+	exampleCall(ctx, lis)
+
+	cancel()
+
+	// Output: /test.service/test.call rpc handled!
+	// got response from server: bye
+}
+
+func exampleServer() *grpc.Server {
+	encoding.RegisterCodec(noopCodec{})
+	return grpc.NewServer(grpc.UnknownServiceHandler(unknownServiceHandler))
+}
+
+func unknownServiceHandler(srv interface{}, stream grpc.ServerStream) error {
+	fullMethodName, ok := grpc.MethodFromServerStream(stream)
+	if !ok {
+		return errors.New("could not determine method from server stream")
+	}
+
+	fmt.Println(fullMethodName, "rpc handled!")
+
+	return stream.SendMsg([]byte("bye"))
+}
+
+func exampleCall(ctx context.Context, lis *bufconn.Listener) {
+	cc, err := grpc.DialContext(
+		ctx, "",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return lis.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.CustomCodecCallOption{Codec: noopCodec{}}),
+	)
+	if err != nil {
+		panic(err)
+	}
+	defer cc.Close()
+
+	var out []byte
+	err = cc.Invoke(ctx, "/test.service/test.call", nil, &out)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("got response from server:", string(out))
+}
+
+type noopCodec struct{}
+
+func (noopCodec) Marshal(v interface{}) ([]byte, error) {
+	return v.([]byte), nil
+}
+
+func (noopCodec) Unmarshal(data []byte, v interface{}) error {
+	*(v.(*[]byte)) = data
+	return nil
+}
+
+func (noopCodec) Name() string {
+	return "noop-codec"
+}
+
+func (noopCodec) String() string {
+	return "noop-codec"
+}

--- a/grpcx/example_daemon_test.go
+++ b/grpcx/example_daemon_test.go
@@ -21,7 +21,7 @@ func ExampleDaemon_Run() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	app := exampleApplication{}
-	dae := grpcx.NewDaemon(server, grpcx.WithListener(lis), grpcx.WithApplications(app))
+	dae := grpcx.NewDaemon(server, lis, grpcx.WithApplications(app))
 	go dae.Run(ctx)
 
 	exampleCall(ctx, lis)

--- a/grpcx/example_daemon_test.go
+++ b/grpcx/example_daemon_test.go
@@ -36,10 +36,10 @@ func ExampleDaemon_Run() {
 
 func exampleServer() *grpc.Server {
 	encoding.RegisterCodec(noopCodec{})
-	return grpc.NewServer(grpc.UnknownServiceHandler(unknownServiceHandler))
+	return grpc.NewServer(grpc.UnknownServiceHandler(exampleServiceHandler))
 }
 
-func unknownServiceHandler(srv interface{}, stream grpc.ServerStream) error {
+func exampleServiceHandler(srv interface{}, stream grpc.ServerStream) error {
 	fullMethodName, ok := grpc.MethodFromServerStream(stream)
 	if !ok {
 		return errors.New("could not determine method from server stream")
@@ -71,25 +71,6 @@ func exampleCall(ctx context.Context, lis *bufconn.Listener) {
 	}
 
 	fmt.Println("got response from server:", string(out))
-}
-
-type noopCodec struct{}
-
-func (noopCodec) Marshal(v interface{}) ([]byte, error) {
-	return v.([]byte), nil
-}
-
-func (noopCodec) Unmarshal(data []byte, v interface{}) error {
-	*(v.(*[]byte)) = data
-	return nil
-}
-
-func (noopCodec) Name() string {
-	return "noop-codec"
-}
-
-func (noopCodec) String() string {
-	return "noop-codec"
 }
 
 type exampleApplication struct {


### PR DESCRIPTION
Introduces a gRPC Daemon type to manage the lifecycle of a gRPC server.

A Daemon is composed of one or more Applications. The responsibility of the Daemon is to bootstrap every Application and to start and gracefully stop the gRPC server.

Each Application is a `contextx.Runner` with the added responsibility of registering their gRPC services into a `grpc.ServiceRegistrar`.